### PR TITLE
Add yard planning web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# Yard Layout Planner Repository Guide
+
+Follow these steps to publish the planner on GitHub:
+
+## 1. Prepare the repository locally
+1. Ensure you are in the project directory:
+   ```bash
+   cd /path/to/your/project
+   ```
+2. Initialize Git if you have not already:
+   ```bash
+   git init
+   ```
+3. Configure your author details (only required once per machine):
+   ```bash
+   git config user.name "Your Name"
+   git config user.email "you@example.com"
+   ```
+
+## 2. Review the project state
+1. Check which files will be tracked:
+   ```bash
+   git status
+   ```
+2. Optionally, add a `.gitignore` file to exclude generated assets.
+
+## 3. Commit your work
+1. Stage the project files:
+   ```bash
+   git add index.html style.css script.js README.md
+   ```
+2. Create an initial commit:
+   ```bash
+   git commit -m "Initial commit"
+   ```
+
+## 4. Create a GitHub repository
+1. Visit [https://github.com/new](https://github.com/new) and create a repository (without initializing with a README if you already have one locally).
+2. Copy the repository's `git remote add` command from the Quick Setup instructions.
+
+## 5. Connect and push
+1. Add the remote (replace the URL with your repository's URL):
+   ```bash
+   git remote add origin git@github.com:username/repo.git
+   ```
+   or, if using HTTPS:
+   ```bash
+   git remote add origin https://github.com/username/repo.git
+   ```
+2. Push the local commit to GitHub:
+   ```bash
+   git push -u origin main
+   ```
+   If GitHub suggests `master` or another default branch name, use that instead of `main`.
+
+## 6. Verify on GitHub
+1. Refresh the new GitHub repository page to confirm the files are present.
+2. Update the repository description or settings as needed.
+
+## 7. Continue developing
+- Repeat the `git add`, `git commit`, and `git push` cycle for subsequent changes.
+- Create feature branches when collaborating to keep work organized.
+
+## Troubleshooting tips
+- If authentication fails, ensure your SSH keys or HTTPS credentials are configured.
+- Run `git status` frequently to understand the repository state.
+- Use `git log --oneline` to review commit history.
+- If a push is rejected, fetch the latest remote changes (`git pull --rebase origin main`) and resolve conflicts before retrying.

--- a/assets/ssmanager-logo.svg
+++ b/assets/ssmanager-logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 160" role="img" aria-labelledby="title desc">
+  <title id="title">SSManager logo</title>
+  <desc id="desc">Stylised red S emblem with SSManager tagline</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff5146" />
+      <stop offset="100%" stop-color="#d21616" />
+    </linearGradient>
+  </defs>
+  <g transform="translate(20 20)">
+    <path fill="url(#grad)" d="M0 0h160l60 34-60 34H0z" />
+    <path fill="url(#grad)" d="M0 66h160l60 34-60 34H0z" />
+    <path fill="url(#grad)" d="M110 33h110l60 34-60 34H110z" opacity="0.9" />
+  </g>
+  <g fill="#ffffff" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+    <text x="220" y="82" font-size="64" font-weight="600">SSManager</text>
+    <text x="220" y="120" font-size="24" opacity="0.7">Precision yard orchestration</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,58 +7,145 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="app">
-    <aside class="sidebar" aria-label="Project sidebar">
-      <section class="yards-panel" aria-labelledby="yardsHeading">
-        <div class="panel-header">
-          <h1 id="yardsHeading">Yards</h1>
-          <div class="yard-actions">
-            <button id="newYardBtn" type="button">New Yard</button>
-            <button id="renameYardBtn" type="button">Rename</button>
-            <button id="duplicateYardBtn" type="button">Duplicate</button>
-            <button id="deleteYardBtn" type="button">Delete</button>
-          </div>
-        </div>
-        <ul id="yardList" class="yard-list" aria-label="Saved yards"></ul>
-      </section>
-
-      <section class="palette" aria-label="Container palette">
-        <h2>Container Palette</h2>
-        <p class="palette-hint">Drag a container into the yard below. Containers snap to the grid when snapping is enabled.</p>
-        <div id="paletteItems" class="palette-items"></div>
-      </section>
-
-      <section class="legend" aria-label="Container legend">
-        <h2>Legend</h2>
-        <ul id="legendList"></ul>
-      </section>
-    </aside>
-
-    <main class="workspace">
-      <header class="workspace-header">
-        <div class="yard-summary" id="yardSummary" aria-live="polite"></div>
-        <div class="workspace-controls">
-          <label class="snap-toggle">
-            <input type="checkbox" id="snapToggle" checked>
-            <span>Snap to grid</span>
-          </label>
-          <span id="scaleInfo" class="scale-info" aria-live="polite"></span>
-        </div>
-      </header>
-
-      <section class="workspace-help" aria-live="polite">
-        <h2 class="sr-only">Keyboard and interaction help</h2>
-        <p>Use the Delete key to remove the selected container. Arrow keys nudge by one grid unit. Press “R” to rotate 90 degrees.</p>
-      </section>
-
-      <div class="yard-wrapper" id="yardWrapper">
-        <div id="hint" class="hint" role="status" aria-live="polite"></div>
-        <svg id="yardSvg" class="yard-svg" tabindex="0" aria-label="Yard layout" preserveAspectRatio="xMidYMid meet"></svg>
-        <div id="emptyState" class="empty-state" hidden>
-          <p>No yard selected. Create a new yard to get started.</p>
+  <div class="app-shell">
+    <header class="app-header">
+      <div class="brand-block">
+        <div class="brand-mark" aria-hidden="true">YL</div>
+        <div class="brand-copy">
+          <h1>Yard Layout Planner</h1>
+          <p>Design and manage modern container yards</p>
         </div>
       </div>
-    </main>
+      <div class="header-actions">
+        <button id="newYardBtn" type="button" class="btn btn-primary">Create Yard</button>
+      </div>
+    </header>
+
+    <div class="app-body">
+      <aside class="panel panel-left" aria-label="Projects and palette">
+        <section class="panel-section">
+          <div class="section-header">
+            <h2>Projects</h2>
+            <div class="section-actions">
+              <button id="renameYardBtn" type="button" class="btn btn-ghost">Rename</button>
+              <button id="duplicateYardBtn" type="button" class="btn btn-ghost">Duplicate</button>
+              <button id="deleteYardBtn" type="button" class="btn btn-danger">Delete</button>
+            </div>
+          </div>
+          <ul id="yardList" class="yard-list" aria-label="Saved yards"></ul>
+        </section>
+
+        <section class="panel-section palette" aria-label="Container palette">
+          <div class="section-header">
+            <h2>Container Palette</h2>
+            <span class="section-hint">Drag into the yard to place</span>
+          </div>
+          <div id="paletteItems" class="palette-items"></div>
+        </section>
+
+        <section class="panel-section legend" aria-label="Container legend">
+          <div class="section-header">
+            <h2>Legend</h2>
+          </div>
+          <ul id="legendList" class="legend-list"></ul>
+        </section>
+      </aside>
+
+      <main class="workspace" aria-label="Yard workspace">
+        <div class="workspace-bar">
+          <div class="yard-summary" id="yardSummary" aria-live="polite"></div>
+          <div class="workspace-controls">
+            <label class="switch">
+              <input type="checkbox" id="snapToggle" checked>
+              <span class="switch-slider"></span>
+              <span class="switch-label">Snap to grid</span>
+            </label>
+            <span id="scaleInfo" class="scale-info" aria-live="polite"></span>
+          </div>
+        </div>
+
+        <section class="workspace-help" aria-live="polite">
+          <h2 class="sr-only">Keyboard and interaction help</h2>
+          <ul class="help-chips">
+            <li><span class="key">Delete</span> remove</li>
+            <li><span class="key">← → ↑ ↓</span> nudge</li>
+            <li><span class="key">R</span> rotate 90°</li>
+          </ul>
+        </section>
+
+        <div class="yard-wrapper" id="yardWrapper">
+          <div id="hint" class="hint" role="status" aria-live="polite"></div>
+          <svg id="yardSvg" class="yard-svg" tabindex="0" aria-label="Yard layout" preserveAspectRatio="xMidYMid meet"></svg>
+          <div id="emptyState" class="empty-state">
+            <div class="empty-card">
+              <h3>No yard selected</h3>
+              <p>Create a yard to begin arranging containers.</p>
+              <button type="button" class="btn btn-primary" data-trigger="create-yard">Create Yard</button>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <aside class="panel panel-right" aria-label="Container details">
+        <section class="panel-section details-panel">
+          <div class="section-header">
+            <h2>Container Details</h2>
+          </div>
+          <div id="detailPlaceholder" class="detail-placeholder">
+            <p>Select a container to edit its info.</p>
+          </div>
+          <form id="containerForm" class="detail-form" hidden>
+            <div class="form-row">
+              <label for="detailTitle">Container title</label>
+              <input id="detailTitle" name="label" type="text" autocomplete="off" required placeholder="Container number">
+            </div>
+            <div class="form-row">
+              <label for="detailRenter">Rented by</label>
+              <input id="detailRenter" name="renter" type="text" autocomplete="off" placeholder="Client name">
+            </div>
+            <div class="form-row">
+              <label for="detailRate">Monthly rate</label>
+              <input id="detailRate" name="monthlyRate" type="number" min="0" step="0.01" placeholder="0.00">
+            </div>
+            <div class="form-row">
+              <label for="detailPhone">Client phone</label>
+              <input id="detailPhone" name="phone" type="tel" autocomplete="off" placeholder="(555) 123-4567">
+            </div>
+          </form>
+        </section>
+      </aside>
+    </div>
+  </div>
+
+  <div id="yardModal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="yardModalTitle" hidden>
+    <div class="modal">
+      <form id="yardForm" class="modal-content">
+        <header class="modal-header">
+          <h2 id="yardModalTitle">Create a Yard</h2>
+          <button type="button" class="btn-icon" id="yardModalClose" aria-label="Close create yard dialog">×</button>
+        </header>
+        <div class="modal-body">
+          <div class="form-grid">
+            <label for="yardNameInput">Yard name</label>
+            <input id="yardNameInput" name="name" type="text" required>
+            <label for="yardWidthInput">Width</label>
+            <input id="yardWidthInput" name="width" type="number" min="1" step="0.01" required>
+            <label for="yardHeightInput">Height</label>
+            <input id="yardHeightInput" name="height" type="number" min="1" step="0.01" required>
+            <label for="yardUnitSelect">Units</label>
+            <select id="yardUnitSelect" name="unit" required>
+              <option value="ft">Feet (ft)</option>
+              <option value="m">Meters (m)</option>
+              <option value="cm">Centimeters (cm)</option>
+            </select>
+          </div>
+        </div>
+        <footer class="modal-footer">
+          <button type="button" class="btn" id="yardModalCancel">Cancel</button>
+          <button type="submit" class="btn btn-primary">Create yard</button>
+        </footer>
+      </form>
+    </div>
   </div>
 
   <script type="module" src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
   <div class="app-shell" data-theme="light">
     <header class="app-header">
       <div class="brand-block">
-        <div class="brand-mark" aria-hidden="true">SS</div>
-        <div class="brand-copy">
+        <img src="assets/ssmanager-logo.svg" alt="SSManager – Precision yard orchestration" class="brand-logo">
+        <div class="sr-only">
           <h1>SSManager</h1>
           <p>Precision yard orchestration</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
               <thead>
                 <tr>
                   <th scope="col">Container</th>
+                  <th scope="col">Size</th>
                   <th scope="col">Renter</th>
                   <th scope="col">Phone</th>
                   <th scope="col" class="numeric">Monthly rate</th>

--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
 <body>
   <div class="app">
     <aside class="sidebar" aria-label="Project sidebar">
-      <section class="yards-panel">
+      <section class="yards-panel" aria-labelledby="yardsHeading">
         <div class="panel-header">
-          <h1>Yards</h1>
+          <h1 id="yardsHeading">Yards</h1>
           <div class="yard-actions">
             <button id="newYardBtn" type="button">New Yard</button>
             <button id="renameYardBtn" type="button">Rename</button>
@@ -24,7 +24,7 @@
 
       <section class="palette" aria-label="Container palette">
         <h2>Container Palette</h2>
-        <p class="palette-hint">Drag a container into the yard.</p>
+        <p class="palette-hint">Drag a container into the yard below. Containers snap to the grid when snapping is enabled.</p>
         <div id="paletteItems" class="palette-items"></div>
       </section>
 
@@ -45,6 +45,11 @@
           <span id="scaleInfo" class="scale-info" aria-live="polite"></span>
         </div>
       </header>
+
+      <section class="workspace-help" aria-live="polite">
+        <h2 class="sr-only">Keyboard and interaction help</h2>
+        <p>Use the Delete key to remove the selected container. Arrow keys nudge by one grid unit. Press “R” to rotate 90 degrees.</p>
+      </section>
 
       <div class="yard-wrapper" id="yardWrapper">
         <div id="hint" class="hint" role="status" aria-live="polite"></div>

--- a/index.html
+++ b/index.html
@@ -3,20 +3,25 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Yard Layout Planner</title>
+  <title>SSManager</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="app-shell">
+  <div class="app-shell" data-theme="light">
     <header class="app-header">
       <div class="brand-block">
-        <div class="brand-mark" aria-hidden="true">YL</div>
+        <div class="brand-mark" aria-hidden="true">SS</div>
         <div class="brand-copy">
-          <h1>Yard Layout Planner</h1>
-          <p>Design and manage modern container yards</p>
+          <h1>SSManager</h1>
+          <p>Precision yard orchestration</p>
         </div>
       </div>
       <div class="header-actions">
+        <label class="switch switch-theme" for="themeToggle">
+          <input type="checkbox" id="themeToggle" aria-label="Toggle dark mode">
+          <span class="switch-slider"></span>
+          <span class="switch-label">Dark mode</span>
+        </label>
         <button id="newYardBtn" type="button" class="btn btn-primary">Create Yard</button>
       </div>
     </header>
@@ -25,7 +30,7 @@
       <aside class="panel panel-left" aria-label="Projects and palette">
         <section class="panel-section">
           <div class="section-header">
-            <h2>Projects</h2>
+            <h2>Yards</h2>
             <div class="section-actions">
               <button id="renameYardBtn" type="button" class="btn btn-ghost">Rename</button>
               <button id="duplicateYardBtn" type="button" class="btn btn-ghost">Duplicate</button>
@@ -37,53 +42,83 @@
 
         <section class="panel-section palette" aria-label="Container palette">
           <div class="section-header">
-            <h2>Container Palette</h2>
-            <span class="section-hint">Drag into the yard to place</span>
+            <h2>Containers</h2>
+            <span class="section-hint">Drag to add</span>
           </div>
           <div id="paletteItems" class="palette-items"></div>
-        </section>
-
-        <section class="panel-section legend" aria-label="Container legend">
-          <div class="section-header">
-            <h2>Legend</h2>
-          </div>
-          <ul id="legendList" class="legend-list"></ul>
         </section>
       </aside>
 
       <main class="workspace" aria-label="Yard workspace">
-        <div class="workspace-bar">
-          <div class="yard-summary" id="yardSummary" aria-live="polite"></div>
-          <div class="workspace-controls">
-            <label class="switch">
-              <input type="checkbox" id="snapToggle" checked>
-              <span class="switch-slider"></span>
-              <span class="switch-label">Snap to grid</span>
-            </label>
-            <span id="scaleInfo" class="scale-info" aria-live="polite"></span>
+        <div class="workspace-stack">
+          <div class="workspace-bar">
+            <div class="yard-summary" id="yardSummary" aria-live="polite"></div>
+            <div class="workspace-controls">
+              <label class="switch">
+                <input type="checkbox" id="snapToggle" checked>
+                <span class="switch-slider"></span>
+                <span class="switch-label">Snap to grid</span>
+              </label>
+              <span id="scaleInfo" class="scale-info" aria-live="polite"></span>
+            </div>
           </div>
-        </div>
 
-        <section class="workspace-help" aria-live="polite">
-          <h2 class="sr-only">Keyboard and interaction help</h2>
-          <ul class="help-chips">
-            <li><span class="key">Delete</span> remove</li>
-            <li><span class="key">← → ↑ ↓</span> nudge</li>
-            <li><span class="key">R</span> rotate 90°</li>
-          </ul>
-        </section>
+          <section class="workspace-help" aria-live="polite">
+            <h2 class="sr-only">Keyboard and interaction help</h2>
+            <ul class="help-chips">
+              <li><span class="key">Delete</span> remove</li>
+              <li><span class="key">← → ↑ ↓</span> nudge</li>
+              <li><span class="key">R</span> rotate 90°</li>
+            </ul>
+          </section>
 
-        <div class="yard-wrapper" id="yardWrapper">
-          <div id="hint" class="hint" role="status" aria-live="polite"></div>
-          <svg id="yardSvg" class="yard-svg" tabindex="0" aria-label="Yard layout" preserveAspectRatio="xMidYMid meet"></svg>
-          <div id="emptyState" class="empty-state">
-            <div class="empty-card">
-              <h3>No yard selected</h3>
-              <p>Create a yard to begin arranging containers.</p>
-              <button type="button" class="btn btn-primary" data-trigger="create-yard">Create Yard</button>
+          <div class="yard-wrapper" id="yardWrapper">
+            <div id="hint" class="hint" role="status" aria-live="polite"></div>
+            <svg id="yardSvg" class="yard-svg" tabindex="0" aria-label="Yard layout" preserveAspectRatio="xMidYMid meet"></svg>
+            <div id="emptyState" class="empty-state">
+              <div class="empty-card">
+                <h3>No yard selected</h3>
+                <p>Create a yard to begin arranging containers.</p>
+                <button type="button" class="btn btn-primary" data-trigger="create-yard">Create Yard</button>
+              </div>
             </div>
           </div>
         </div>
+
+        <section class="inventory-panel" aria-label="Container roster">
+          <header class="inventory-header">
+            <h2>Container Roster</h2>
+            <p>Scroll to review occupants and contact information.</p>
+          </header>
+          <div class="inventory-table-wrapper">
+            <table class="inventory-table">
+              <thead>
+                <tr>
+                  <th scope="col">Container</th>
+                  <th scope="col">Renter</th>
+                  <th scope="col">Phone</th>
+                  <th scope="col" class="numeric">Monthly rate</th>
+                </tr>
+              </thead>
+              <tbody id="inventoryBody"></tbody>
+            </table>
+          </div>
+          <section class="inventory-overview" aria-live="polite">
+            <h3>Monthly overview</h3>
+            <div class="overview-row">
+              <span>Total containers</span>
+              <strong id="overviewCount">0</strong>
+            </div>
+            <div class="overview-row">
+              <span>Occupied</span>
+              <strong id="overviewOccupied">0</strong>
+            </div>
+            <div class="overview-row">
+              <span>Monthly revenue</span>
+              <strong id="overviewRevenue">$0.00</strong>
+            </div>
+          </section>
+        </section>
       </main>
 
       <aside class="panel panel-right" aria-label="Container details">
@@ -95,6 +130,13 @@
             <p>Select a container to edit its info.</p>
           </div>
           <form id="containerForm" class="detail-form" hidden>
+            <div class="form-row">
+              <label class="switch">
+                <input id="detailOccupied" name="occupied" type="checkbox">
+                <span class="switch-slider"></span>
+                <span class="switch-label">Container occupied</span>
+              </label>
+            </div>
             <div class="form-row">
               <label for="detailTitle">Container title</label>
               <input id="detailTitle" name="label" type="text" autocomplete="off" required placeholder="Container number">

--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Yard Layout Planner</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar" aria-label="Project sidebar">
+      <section class="yards-panel">
+        <div class="panel-header">
+          <h1>Yards</h1>
+          <div class="yard-actions">
+            <button id="newYardBtn" type="button">New Yard</button>
+            <button id="renameYardBtn" type="button">Rename</button>
+            <button id="duplicateYardBtn" type="button">Duplicate</button>
+            <button id="deleteYardBtn" type="button">Delete</button>
+          </div>
+        </div>
+        <ul id="yardList" class="yard-list" aria-label="Saved yards"></ul>
+      </section>
+
+      <section class="palette" aria-label="Container palette">
+        <h2>Container Palette</h2>
+        <p class="palette-hint">Drag a container into the yard.</p>
+        <div id="paletteItems" class="palette-items"></div>
+      </section>
+
+      <section class="legend" aria-label="Container legend">
+        <h2>Legend</h2>
+        <ul id="legendList"></ul>
+      </section>
+    </aside>
+
+    <main class="workspace">
+      <header class="workspace-header">
+        <div class="yard-summary" id="yardSummary" aria-live="polite"></div>
+        <div class="workspace-controls">
+          <label class="snap-toggle">
+            <input type="checkbox" id="snapToggle" checked>
+            <span>Snap to grid</span>
+          </label>
+          <span id="scaleInfo" class="scale-info" aria-live="polite"></span>
+        </div>
+      </header>
+
+      <div class="yard-wrapper" id="yardWrapper">
+        <div id="hint" class="hint" role="status" aria-live="polite"></div>
+        <svg id="yardSvg" class="yard-svg" tabindex="0" aria-label="Yard layout" preserveAspectRatio="xMidYMid meet"></svg>
+        <div id="emptyState" class="empty-state" hidden>
+          <p>No yard selected. Create a new yard to get started.</p>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,8 @@
               <li><span class="key">Delete</span> remove</li>
               <li><span class="key">← → ↑ ↓</span> nudge</li>
               <li><span class="key">R</span> rotate 90°</li>
+              <li><span class="key">Scroll</span> zoom</li>
+              <li><span class="key">Middle drag</span> pan</li>
             </ul>
           </section>
 
@@ -153,6 +155,12 @@
               <label for="detailPhone">Client phone</label>
               <input id="detailPhone" name="phone" type="tel" autocomplete="off" placeholder="(555) 123-4567">
             </div>
+            <fieldset class="form-row door-fieldset">
+              <legend>Doors</legend>
+              <p class="door-hint">Add entry points and adjust their placement along the container edges.</p>
+              <div id="doorList" class="door-list" role="list"></div>
+              <button type="button" class="btn btn-ghost" id="addDoorBtn">Add door</button>
+            </fieldset>
           </form>
         </section>
       </aside>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,788 @@
+const STORAGE_KEY = 'yards_v1';
+const ACTIVE_KEY = 'yards_active_id_v1';
+const containerDepthFt = 8;
+
+/** @type {const} */
+const containerTypes = [
+  { type: '5ft', widthFt: 5, color: '#8ecae6' },
+  { type: '10ft', widthFt: 10, color: '#a3bffa' },
+  { type: '20ft', widthFt: 20, color: '#facc15' },
+  { type: '40ft', widthFt: 40, color: '#f87171' },
+  { type: '50ft', widthFt: 50, color: '#c084fc' },
+];
+
+const ftToUnitFactor = {
+  ft: 1,
+  m: 0.3048,
+  cm: 30.48,
+};
+
+const state = {
+  yards: [],
+  activeYardId: null,
+  snapEnabled: true,
+  scale: 1,
+};
+
+let selectedContainerId = null;
+let currentDrag = null;
+let hintTimeout = null;
+
+const els = {
+  yardList: document.getElementById('yardList'),
+  newYardBtn: document.getElementById('newYardBtn'),
+  renameYardBtn: document.getElementById('renameYardBtn'),
+  duplicateYardBtn: document.getElementById('duplicateYardBtn'),
+  deleteYardBtn: document.getElementById('deleteYardBtn'),
+  paletteItems: document.getElementById('paletteItems'),
+  legendList: document.getElementById('legendList'),
+  snapToggle: document.getElementById('snapToggle'),
+  yardSummary: document.getElementById('yardSummary'),
+  scaleInfo: document.getElementById('scaleInfo'),
+  hint: document.getElementById('hint'),
+  yardSvg: document.getElementById('yardSvg'),
+  emptyState: document.getElementById('emptyState'),
+  yardWrapper: document.getElementById('yardWrapper'),
+};
+
+init();
+
+function init() {
+  loadState();
+  renderPalette();
+  renderLegend();
+  attachEventListeners();
+  renderAll();
+}
+
+function loadState() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        state.yards = parsed;
+      }
+    }
+    const activeId = localStorage.getItem(ACTIVE_KEY);
+    if (activeId) {
+      state.activeYardId = activeId;
+    }
+  } catch (err) {
+    console.warn('Failed to load yards from storage', err);
+    state.yards = [];
+    state.activeYardId = null;
+  }
+  if (!state.activeYardId && state.yards.length > 0) {
+    state.activeYardId = state.yards[0].id;
+  }
+}
+
+function saveState() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.yards));
+  if (state.activeYardId) {
+    localStorage.setItem(ACTIVE_KEY, state.activeYardId);
+  }
+}
+
+function attachEventListeners() {
+  els.newYardBtn.addEventListener('click', handleCreateYard);
+  els.renameYardBtn.addEventListener('click', handleRenameYard);
+  els.duplicateYardBtn.addEventListener('click', handleDuplicateYard);
+  els.deleteYardBtn.addEventListener('click', handleDeleteYard);
+  els.snapToggle.addEventListener('change', () => {
+    state.snapEnabled = els.snapToggle.checked;
+    renderScaleInfo();
+  });
+
+  els.yardSvg.addEventListener('pointerdown', (event) => {
+    if (event.target === els.yardSvg) {
+      selectContainer(null);
+    }
+  });
+
+  els.yardSvg.addEventListener('pointermove', handlePointerMove);
+  els.yardSvg.addEventListener('pointerup', handlePointerUp);
+  els.yardSvg.addEventListener('pointercancel', handlePointerUp);
+
+  document.addEventListener('pointermove', handleGlobalPointerMove);
+  document.addEventListener('pointerup', handleGlobalPointerUp);
+  document.addEventListener('keydown', handleKeyDown);
+  window.addEventListener('resize', () => renderActiveYard());
+}
+
+function renderAll() {
+  renderYardList();
+  renderActiveYard();
+  renderScaleInfo();
+}
+
+function renderPalette() {
+  els.paletteItems.innerHTML = '';
+  containerTypes.forEach((type) => {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'palette-item';
+    item.dataset.type = type.type;
+    item.innerHTML = `
+      <span>${type.widthFt} ft container</span>
+      <span class="swatch" style="background:${type.color}"></span>
+    `;
+    item.addEventListener('pointerdown', (event) => startPaletteDrag(event, type));
+    item.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        startPaletteDragFromKeyboard(type);
+      }
+    });
+    els.paletteItems.appendChild(item);
+  });
+}
+
+function renderLegend() {
+  els.legendList.innerHTML = '';
+  containerTypes.forEach((type) => {
+    const li = document.createElement('li');
+    li.innerHTML = `
+      <span class="swatch" style="background:${type.color}"></span>
+      <span>${type.widthFt} ft container</span>
+    `;
+    els.legendList.appendChild(li);
+  });
+}
+
+function renderYardList() {
+  els.yardList.innerHTML = '';
+  state.yards.forEach((yard) => {
+    const li = document.createElement('li');
+    const button = document.createElement('button');
+    button.textContent = `${yard.name}`;
+    button.classList.toggle('active', yard.id === state.activeYardId);
+    button.addEventListener('click', () => {
+      state.activeYardId = yard.id;
+      saveState();
+      renderAll();
+    });
+    li.appendChild(button);
+    els.yardList.appendChild(li);
+  });
+}
+
+function renderActiveYard() {
+  const yard = getActiveYard();
+  const previouslySelected = selectedContainerId;
+  els.yardSvg.innerHTML = '';
+
+  if (!yard) {
+    els.yardSvg.setAttribute('width', '100%');
+    els.yardSvg.setAttribute('height', '100%');
+    els.emptyState.hidden = false;
+    els.yardSummary.textContent = '';
+    selectContainer(null);
+    return;
+  }
+
+  els.emptyState.hidden = true;
+  const available = els.yardWrapper.getBoundingClientRect();
+  const padding = 32;
+  const availableWidth = Math.max(available.width - padding, 200);
+  const availableHeight = Math.max(available.height - padding, 200);
+  const scaleCandidate = Math.min(
+    availableWidth / yard.width,
+    availableHeight / yard.height
+  );
+  const minScale = 8 / convertFtToUnit(1, yard.unit);
+  const scale = Math.max(scaleCandidate, minScale);
+  state.scale = scale;
+
+  els.yardSvg.setAttribute('viewBox', `0 0 ${yard.width} ${yard.height}`);
+  els.yardSvg.setAttribute('width', yard.width * scale);
+  els.yardSvg.setAttribute('height', yard.height * scale);
+
+  renderGrid(yard);
+  renderContainers(yard);
+  if (
+    previouslySelected &&
+    yard.containers.some((container) => container.id === previouslySelected)
+  ) {
+    selectContainer(previouslySelected);
+  } else {
+    selectContainer(null);
+  }
+  els.yardSummary.textContent = `${yard.name} — ${yard.width} × ${yard.height} ${yard.unit}`;
+}
+
+function renderGrid(yard) {
+  const gridSize = gridUnit(yard.unit);
+  const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+  const pattern = document.createElementNS('http://www.w3.org/2000/svg', 'pattern');
+  pattern.setAttribute('id', 'grid-pattern');
+  pattern.setAttribute('patternUnits', 'userSpaceOnUse');
+  pattern.setAttribute('width', gridSize);
+  pattern.setAttribute('height', gridSize);
+
+  const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  rect.setAttribute('width', gridSize);
+  rect.setAttribute('height', gridSize);
+  rect.setAttribute('fill', 'none');
+  rect.setAttribute('stroke', '#cbd5e1');
+  rect.setAttribute('stroke-width', 0.03);
+
+  pattern.appendChild(rect);
+  defs.appendChild(pattern);
+  els.yardSvg.appendChild(defs);
+
+  const background = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  background.setAttribute('width', yard.width);
+  background.setAttribute('height', yard.height);
+  background.setAttribute('fill', 'url(#grid-pattern)');
+  background.setAttribute('stroke', '#94a3b8');
+  background.setAttribute('stroke-width', 0.1);
+  els.yardSvg.appendChild(background);
+}
+
+function renderContainers(yard) {
+  yard.containers.forEach((container) => {
+    const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    group.classList.add('container-group');
+    group.dataset.id = container.id;
+    group.dataset.type = container.type;
+    group.setAttribute('tabindex', '0');
+
+    const dims = getContainerDimensions(yard, container);
+
+    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.classList.add('container-rect');
+    rect.setAttribute('width', dims.width);
+    rect.setAttribute('height', dims.height);
+    rect.setAttribute('rx', 0.2);
+    rect.setAttribute('ry', 0.2);
+
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.classList.add('container-label');
+    text.setAttribute('x', dims.width / 2);
+    text.setAttribute('y', dims.height / 2);
+    text.setAttribute('dominant-baseline', 'middle');
+    text.setAttribute('text-anchor', 'middle');
+    text.textContent = `${container.widthFt} ft${container.rotation === 90 ? ' ⟳' : ''}`;
+
+    group.appendChild(rect);
+    group.appendChild(text);
+    setContainerTransform(group, container.x, container.y);
+
+    group.addEventListener('pointerdown', (event) => handleContainerPointerDown(event, container.id));
+    group.addEventListener('focus', () => selectContainer(container.id));
+    group.addEventListener('blur', () => {
+      if (selectedContainerId === container.id) {
+        selectContainer(null);
+      }
+    });
+
+    els.yardSvg.appendChild(group);
+  });
+}
+
+function renderScaleInfo() {
+  const yard = getActiveYard();
+  if (!yard) {
+    els.scaleInfo.textContent = '';
+    return;
+  }
+  const unitStep = gridUnit(yard.unit);
+  const gridLabel = formatNumber(unitStep);
+  els.scaleInfo.textContent = `Grid: 1 ft = ${gridLabel} ${yard.unit} (${state.snapEnabled ? 'snap on' : 'snap off'})`;
+  els.snapToggle.checked = state.snapEnabled;
+}
+
+function startPaletteDrag(event, type) {
+  event.preventDefault();
+  const pointerId = event.pointerId;
+  currentDrag = {
+    mode: 'palette',
+    pointerId,
+    type,
+    ghost: createGhost(type),
+  };
+  document.body.appendChild(currentDrag.ghost);
+  updateGhostPosition(event);
+  document.addEventListener('pointermove', updateGhostPosition);
+}
+
+function startPaletteDragFromKeyboard(type) {
+  const yard = getActiveYard();
+  if (!yard) {
+    showHint('Create a yard before placing containers.');
+    return;
+  }
+  const container = createContainerFromType(yard, type);
+  container.x = 0;
+  container.y = 0;
+  if (!isCollision(yard, container, container.id)) {
+    yard.containers.push(container);
+    saveState();
+    selectedContainerId = container.id;
+    renderActiveYard();
+  } else {
+    showHint('No free space at the origin. Move existing containers.');
+  }
+}
+
+function updateGhostPosition(event) {
+  if (!currentDrag || currentDrag.mode !== 'palette') return;
+  const ghost = currentDrag.ghost;
+  ghost.style.left = `${event.clientX + 12}px`;
+  ghost.style.top = `${event.clientY + 12}px`;
+}
+
+function handleGlobalPointerMove(event) {
+  if (currentDrag && currentDrag.mode === 'palette' && event.pointerId === currentDrag.pointerId) {
+    updateGhostPosition(event);
+  }
+}
+
+function handleGlobalPointerUp(event) {
+  if (!currentDrag) return;
+  if (currentDrag.mode === 'palette' && event.pointerId === currentDrag.pointerId) {
+    finishPaletteDrag(event);
+  }
+}
+
+function finishPaletteDrag(event) {
+  document.removeEventListener('pointermove', updateGhostPosition);
+  if (currentDrag?.ghost) {
+    currentDrag.ghost.remove();
+  }
+  const yard = getActiveYard();
+  if (!yard) {
+    showHint('Create a yard before placing containers.');
+    currentDrag = null;
+    return;
+  }
+  const rect = els.yardSvg.getBoundingClientRect();
+  if (
+    event.clientX < rect.left ||
+    event.clientX > rect.right ||
+    event.clientY < rect.top ||
+    event.clientY > rect.bottom
+  ) {
+    currentDrag = null;
+    return;
+  }
+
+  const pointer = yardPointerToUnits(event);
+  const container = createContainerFromType(yard, currentDrag.type);
+  const dims = getContainerDimensions(yard, container);
+  let x = pointer.x - dims.width / 2;
+  let y = pointer.y - dims.height / 2;
+
+  if (state.snapEnabled) {
+    x = snapValue(x, yard.unit);
+    y = snapValue(y, yard.unit);
+  }
+
+  const clamped = clampToBounds({ x, y }, dims.width, dims.height, yard);
+  container.x = clamped.x;
+  container.y = clamped.y;
+
+  if (isCollision(yard, container, container.id)) {
+    if (state.snapEnabled) {
+      const fallback = findNearestSpot(yard, container, dims.width, dims.height);
+      if (fallback) {
+        container.x = fallback.x;
+        container.y = fallback.y;
+      } else {
+        showHint('No free space available here.');
+        currentDrag = null;
+        return;
+      }
+    } else {
+      showHint('Containers cannot overlap.');
+      currentDrag = null;
+      return;
+    }
+  }
+
+  yard.containers.push(container);
+  saveState();
+  selectedContainerId = container.id;
+  renderActiveYard();
+  currentDrag = null;
+}
+
+function handleContainerPointerDown(event, containerId) {
+  event.preventDefault();
+  event.stopPropagation();
+  const yard = getActiveYard();
+  if (!yard) return;
+  const container = yard.containers.find((c) => c.id === containerId);
+  if (!container) return;
+  selectContainer(containerId);
+  const dims = getContainerDimensions(yard, container);
+  const pointer = yardPointerToUnits(event);
+  const offsetX = pointer.x - container.x;
+  const offsetY = pointer.y - container.y;
+  const group = event.currentTarget;
+  group.classList.add('dragging');
+
+  currentDrag = {
+    mode: 'move',
+    pointerId: event.pointerId,
+    containerId,
+    offsetX,
+    offsetY,
+    element: group,
+    width: dims.width,
+    height: dims.height,
+    lastValid: { x: container.x, y: container.y },
+    valid: true,
+  };
+  group.setPointerCapture(event.pointerId);
+}
+
+function handlePointerMove(event) {
+  if (!currentDrag || currentDrag.mode !== 'move') return;
+  if (event.pointerId !== currentDrag.pointerId) return;
+  const yard = getActiveYard();
+  if (!yard) return;
+  const base = getContainerById(yard, currentDrag.containerId);
+  if (!base) return;
+  const pointer = yardPointerToUnits(event);
+  let x = pointer.x - currentDrag.offsetX;
+  let y = pointer.y - currentDrag.offsetY;
+  if (state.snapEnabled) {
+    x = snapValue(x, yard.unit);
+    y = snapValue(y, yard.unit);
+  }
+  const clamped = clampToBounds({ x, y }, currentDrag.width, currentDrag.height, yard);
+  const candidate = {
+    id: currentDrag.containerId,
+    widthFt: base.widthFt,
+    rotation: base.rotation,
+    x: clamped.x,
+    y: clamped.y,
+  };
+  const collides = isCollision(yard, candidate, currentDrag.containerId);
+  currentDrag.valid = !collides;
+  if (!collides) {
+    currentDrag.lastValid = { x: clamped.x, y: clamped.y };
+    currentDrag.element.classList.remove('invalid');
+  } else {
+    currentDrag.element.classList.add('invalid');
+  }
+  setContainerTransform(currentDrag.element, clamped.x, clamped.y);
+}
+
+function handlePointerUp(event) {
+  if (!currentDrag || currentDrag.mode !== 'move') return;
+  if (event.pointerId !== currentDrag.pointerId) return;
+  const yard = getActiveYard();
+  if (!yard) return;
+  const container = getContainerById(yard, currentDrag.containerId);
+  currentDrag.element.classList.remove('dragging');
+  currentDrag.element.classList.remove('invalid');
+  currentDrag.element.releasePointerCapture(event.pointerId);
+
+  if (currentDrag.valid) {
+    container.x = currentDrag.lastValid.x;
+    container.y = currentDrag.lastValid.y;
+    saveState();
+    renderActiveYard();
+  } else {
+    showHint('Placement blocked by another container.');
+    renderActiveYard();
+  }
+  currentDrag = null;
+}
+
+function handleKeyDown(event) {
+  const yard = getActiveYard();
+  if (!yard || !selectedContainerId) return;
+  const container = getContainerById(yard, selectedContainerId);
+  if (!container) return;
+  const step = state.snapEnabled ? gridUnit(yard.unit) : gridUnit(yard.unit);
+  let handled = false;
+  switch (event.key) {
+    case 'Delete':
+    case 'Backspace':
+      removeSelectedContainer();
+      handled = true;
+      break;
+    case 'ArrowUp':
+      attemptMove(container, 0, -step, yard);
+      handled = true;
+      break;
+    case 'ArrowDown':
+      attemptMove(container, 0, step, yard);
+      handled = true;
+      break;
+    case 'ArrowLeft':
+      attemptMove(container, -step, 0, yard);
+      handled = true;
+      break;
+    case 'ArrowRight':
+      attemptMove(container, step, 0, yard);
+      handled = true;
+      break;
+    case 'r':
+    case 'R':
+      attemptRotate(container, yard);
+      handled = true;
+      break;
+    default:
+      break;
+  }
+  if (handled) {
+    event.preventDefault();
+  }
+}
+
+function attemptMove(container, dx, dy, yard) {
+  const dims = getContainerDimensions(yard, container);
+  const target = {
+    x: container.x + dx,
+    y: container.y + dy,
+  };
+  const clamped = clampToBounds(target, dims.width, dims.height, yard);
+  const candidate = { ...container, ...clamped };
+  if (!isCollision(yard, candidate, container.id)) {
+    container.x = clamped.x;
+    container.y = clamped.y;
+    saveState();
+    renderActiveYard();
+  } else {
+    showHint('Movement blocked by collision or bounds.');
+  }
+}
+
+function attemptRotate(container, yard) {
+  const previousRotation = container.rotation;
+  const nextRotation = previousRotation === 90 ? 0 : 90;
+  container.rotation = nextRotation;
+  const dims = getContainerDimensions(yard, container);
+  const clamped = clampToBounds({ x: container.x, y: container.y }, dims.width, dims.height, yard);
+  const candidate = { ...container, ...clamped };
+  if (!isCollision(yard, candidate, container.id)) {
+    container.x = clamped.x;
+    container.y = clamped.y;
+    saveState();
+    renderActiveYard();
+  } else {
+    container.rotation = previousRotation;
+    showHint('Rotation blocked by bounds or collision.');
+    renderActiveYard();
+  }
+}
+
+function removeSelectedContainer() {
+  const yard = getActiveYard();
+  if (!yard || !selectedContainerId) return;
+  const idx = yard.containers.findIndex((c) => c.id === selectedContainerId);
+  if (idx >= 0) {
+    yard.containers.splice(idx, 1);
+    saveState();
+    renderActiveYard();
+    showHint('Container removed.');
+  }
+}
+
+function startYard(name, width, height, unit) {
+  const yard = {
+    id: generateId(),
+    name,
+    width,
+    height,
+    unit,
+    containers: [],
+  };
+  state.yards.push(yard);
+  state.activeYardId = yard.id;
+  saveState();
+  renderAll();
+}
+
+function handleCreateYard() {
+  const name = prompt('Yard name', `Yard ${state.yards.length + 1}`);
+  if (!name) return;
+  const width = parseFloat(prompt('Width', '100'));
+  const height = parseFloat(prompt('Height', '60'));
+  const unit = prompt('Unit (ft, m, cm)', 'ft');
+  const sanitizedUnit = (unit || 'ft').trim().toLowerCase();
+  if (!['ft', 'm', 'cm'].includes(sanitizedUnit)) {
+    showHint('Invalid unit. Choose ft, m, or cm.');
+    return;
+  }
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    showHint('Width and height must be positive numbers.');
+    return;
+  }
+  startYard(name.trim(), Number(width.toFixed(3)), Number(height.toFixed(3)), sanitizedUnit);
+}
+
+function handleRenameYard() {
+  const yard = getActiveYard();
+  if (!yard) return;
+  const name = prompt('Rename yard', yard.name);
+  if (!name) return;
+  yard.name = name.trim();
+  saveState();
+  renderAll();
+}
+
+function handleDuplicateYard() {
+  const yard = getActiveYard();
+  if (!yard) return;
+  const clone = JSON.parse(JSON.stringify(yard));
+  clone.id = generateId();
+  clone.name = `${yard.name} Copy`;
+  clone.containers = clone.containers.map((container) => ({
+    ...container,
+    id: generateId(),
+  }));
+  state.yards.push(clone);
+  state.activeYardId = clone.id;
+  saveState();
+  renderAll();
+}
+
+function handleDeleteYard() {
+  const yard = getActiveYard();
+  if (!yard) return;
+  if (!confirm(`Delete yard "${yard.name}"?`)) return;
+  state.yards = state.yards.filter((y) => y.id !== yard.id);
+  if (state.activeYardId === yard.id) {
+    state.activeYardId = state.yards[0]?.id || null;
+  }
+  saveState();
+  renderAll();
+}
+
+function selectContainer(containerId) {
+  selectedContainerId = containerId;
+  Array.from(els.yardSvg.querySelectorAll('.container-group')).forEach((group) => {
+    group.classList.toggle('selected', group.dataset.id === containerId);
+  });
+}
+
+function getActiveYard() {
+  if (!state.activeYardId) return null;
+  return state.yards.find((yard) => yard.id === state.activeYardId) || null;
+}
+
+function createContainerFromType(yard, type) {
+  return {
+    id: generateId(),
+    type: type.type,
+    widthFt: type.widthFt,
+    x: 0,
+    y: 0,
+    rotation: 0,
+  };
+}
+
+function yardPointerToUnits(event) {
+  const rect = els.yardSvg.getBoundingClientRect();
+  return {
+    x: (event.clientX - rect.left) / state.scale,
+    y: (event.clientY - rect.top) / state.scale,
+  };
+}
+
+function snapValue(value, unit) {
+  const size = gridUnit(unit);
+  return Math.round(value / size) * size;
+}
+
+function gridUnit(unit) {
+  return convertFtToUnit(1, unit);
+}
+
+function convertFtToUnit(value, unit) {
+  return value * ftToUnitFactor[unit];
+}
+
+function getContainerDimensions(yard, container) {
+  const width = convertFtToUnit(container.widthFt, yard.unit);
+  const depth = convertFtToUnit(containerDepthFt, yard.unit);
+  if (container.rotation === 90) {
+    return { width: depth, height: width };
+  }
+  return { width, height: depth };
+}
+
+function clampToBounds(position, width, height, yard) {
+  return {
+    x: Math.min(Math.max(position.x, 0), Math.max(yard.width - width, 0)),
+    y: Math.min(Math.max(position.y, 0), Math.max(yard.height - height, 0)),
+  };
+}
+
+function isCollision(yard, candidate, ignoreId) {
+  const dims = getContainerDimensions(yard, candidate);
+  return yard.containers.some((container) => {
+    if (container.id === ignoreId) return false;
+    const otherDims = getContainerDimensions(yard, container);
+    return !(
+      candidate.x + dims.width <= container.x ||
+      candidate.x >= container.x + otherDims.width ||
+      candidate.y + dims.height <= container.y ||
+      candidate.y >= container.y + otherDims.height
+    );
+  });
+}
+
+function findNearestSpot(yard, container, width, height) {
+  const startX = container.x;
+  const startY = container.y;
+  const step = gridUnit(yard.unit);
+  const maxRadius = Math.ceil(Math.max(yard.width, yard.height) / step) + 2;
+  for (let radius = 0; radius <= maxRadius && radius < 60; radius++) {
+    for (let dx = -radius; dx <= radius; dx++) {
+      for (let dy = -radius; dy <= radius; dy++) {
+        if (Math.abs(dx) !== radius && Math.abs(dy) !== radius) continue;
+        const x = startX + dx * step;
+        const y = startY + dy * step;
+        const clamped = clampToBounds({ x, y }, width, height, yard);
+        const candidate = { ...container, x: clamped.x, y: clamped.y };
+        if (!isCollision(yard, candidate, container.id)) {
+          return clamped;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function setContainerTransform(group, x, y) {
+  group.setAttribute('transform', `translate(${x}, ${y})`);
+}
+
+function getContainerById(yard, id) {
+  return yard.containers.find((container) => container.id === id);
+}
+
+function createGhost(type) {
+  const ghost = document.createElement('div');
+  ghost.className = 'drag-ghost';
+  ghost.textContent = `${type.widthFt} ft`;
+  ghost.style.borderColor = type.color;
+  return ghost;
+}
+
+function showHint(message) {
+  if (!message) return;
+  els.hint.textContent = message;
+  els.hint.classList.add('visible');
+  if (hintTimeout) window.clearTimeout(hintTimeout);
+  hintTimeout = window.setTimeout(() => {
+    els.hint.classList.remove('visible');
+  }, 1800);
+}
+
+function formatNumber(value) {
+  const rounded = Math.round(value * 1000) / 1000;
+  return Number(rounded.toString()).toString();
+}
+
+function generateId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/script.js
+++ b/script.js
@@ -881,6 +881,10 @@ function handleContainerPointerDown(event, containerId) {
   const offsetY = pointer.y - container.y;
   const group = event.currentTarget;
   group.classList.add('dragging');
+  const parent = group.parentNode;
+  if (parent && parent.lastChild !== group) {
+    parent.appendChild(group);
+  }
 
   currentDrag = {
     mode: 'move',
@@ -1036,19 +1040,10 @@ function attemptRotate(container, yard) {
   }
 
   const clamped = clampToBounds({ x: nextX, y: nextY }, afterDims.width, afterDims.height, yard);
-  const candidate = { ...container, x: clamped.x, y: clamped.y };
-
-  if (!isCollision(yard, candidate, container.id)) {
-    container.x = clamped.x;
-    container.y = clamped.y;
-    saveState();
-    renderActiveYard();
-  } else {
-    container.rotation = previousRotation;
-    container.x = previousPosition.x;
-    container.y = previousPosition.y;
-    renderActiveYard();
-  }
+  container.x = clamped.x;
+  container.y = clamped.y;
+  saveState();
+  renderActiveYard();
 }
 
 function removeSelectedContainer() {

--- a/script.js
+++ b/script.js
@@ -282,16 +282,15 @@ function renderActiveYard() {
   const previouslySelected = selectedContainerId;
   els.yardSvg.innerHTML = '';
 
+  els.emptyState.hidden = Boolean(yard);
   if (!yard) {
     els.yardSvg.setAttribute('width', '100%');
     els.yardSvg.setAttribute('height', '100%');
-    els.emptyState.hidden = false;
     els.yardSummary.textContent = '';
     selectContainer(null);
     return;
   }
 
-  els.emptyState.hidden = true;
   const available = els.yardWrapper.getBoundingClientRect();
   const padding = 32;
   const availableWidth = Math.max(available.width - padding, 200);
@@ -1049,8 +1048,27 @@ function selectContainer(containerId) {
 }
 
 function getActiveYard() {
-  if (!state.activeYardId) return null;
-  return state.yards.find((yard) => yard.id === state.activeYardId) || null;
+  if (!state.yards.length) {
+    if (state.activeYardId) {
+      state.activeYardId = null;
+      saveState();
+    }
+    return null;
+  }
+
+  if (state.activeYardId) {
+    const match = state.yards.find((yard) => yard.id === state.activeYardId);
+    if (match) {
+      return match;
+    }
+  }
+
+  const fallbackId = state.yards[0].id;
+  if (state.activeYardId !== fallbackId) {
+    state.activeYardId = fallbackId;
+    saveState();
+  }
+  return state.yards[0] || null;
 }
 
 function createContainerFromType(yard, type) {

--- a/script.js
+++ b/script.js
@@ -233,8 +233,7 @@ function commitNextContainerLabel(yard) {
   if (!yard) {
     return;
   }
-  const next = ensureNextContainerNumber(yard);
-  yard.nextContainerNumber = next + 1;
+  ensureNextContainerNumber(yard);
 }
 
 function sanitizeDoors(list) {

--- a/style.css
+++ b/style.css
@@ -237,10 +237,11 @@ textarea {
 
 .yard-list li button {
   all: unset;
+  box-sizing: border-box;
   width: 100%;
-  border-radius: 0.65rem;
-  padding: 0.45rem 0.75rem;
-  font-size: 0.9rem;
+  border-radius: 0.6rem;
+  padding: 0.32rem 0.6rem;
+  font-size: 0.82rem;
   cursor: pointer;
   display: flex;
   justify-content: space-between;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,332 @@
+:root {
+  color-scheme: light dark;
+  --sidebar-width: min(320px, 30vw);
+  --bg: #f2f4f8;
+  --sidebar-bg: #1f2933;
+  --sidebar-text: #f5f7fa;
+  --accent: #3b82f6;
+  --accent-light: #93c5fd;
+  --border: #cbd5e1;
+  --danger: #ef4444;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: #1f2933;
+  display: flex;
+}
+
+.app {
+  display: flex;
+  width: 100%;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar h1,
+.sidebar h2 {
+  margin: 0 0 0.75rem 0;
+  font-weight: 600;
+}
+
+.yard-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.yard-actions button {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: #334155;
+  color: var(--sidebar-text);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.yard-actions button:hover,
+.yard-actions button:focus-visible {
+  background: #475569;
+  outline: none;
+}
+
+.yard-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 25vh;
+  overflow: auto;
+}
+
+.yard-list button {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  text-align: left;
+  cursor: pointer;
+}
+
+.yard-list button.active {
+  background: rgba(59, 130, 246, 0.3);
+  border-color: var(--accent-light);
+}
+
+.palette-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.palette-item {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: grab;
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.palette-item:active {
+  cursor: grabbing;
+}
+
+.palette-item .swatch {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 0.35rem;
+}
+
+.legend ul,
+.legend li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem;
+  gap: 1rem;
+}
+
+.workspace-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.workspace-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.snap-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.snap-toggle input {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.yard-wrapper {
+  position: relative;
+  flex: 1;
+  background: white;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  padding: 1rem;
+  overflow: auto;
+}
+
+.yard-svg {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  display: block;
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+}
+
+.container-group {
+  cursor: grab;
+}
+
+.container-group:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.container-rect {
+  fill: var(--accent-light);
+  stroke: #1e3a8a;
+  stroke-width: 0.05;
+  rx: 0.2;
+  ry: 0.2;
+}
+
+.container-group[data-type="5ft"] .container-rect { fill: #8ecae6; stroke: #126782; }
+.container-group[data-type="10ft"] .container-rect { fill: #a3bffa; stroke: #1e3a8a; }
+.container-group[data-type="20ft"] .container-rect { fill: #facc15; stroke: #a16207; }
+.container-group[data-type="40ft"] .container-rect { fill: #f87171; stroke: #b91c1c; }
+.container-group[data-type="50ft"] .container-rect { fill: #c084fc; stroke: #6b21a8; }
+
+.container-label {
+  fill: #1f2933;
+  font-size: 0.7rem;
+  pointer-events: none;
+}
+
+.container-group.selected .container-rect {
+  stroke: #0f172a;
+  stroke-width: 0.12;
+  filter: brightness(0.95);
+}
+
+.container-group.dragging {
+  opacity: 0.7;
+}
+
+.container-group.invalid .container-rect {
+  stroke: var(--danger);
+  stroke-dasharray: 0.4;
+}
+
+.hint {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(30, 64, 175, 0.85);
+  color: white;
+  font-size: 0.85rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 10;
+}
+
+.hint.visible {
+  opacity: 1;
+}
+
+.drag-ghost {
+  position: fixed;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.9);
+  color: #0f172a;
+  border: 2px dashed;
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  font-weight: 600;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.15);
+  z-index: 20;
+}
+
+.empty-state {
+  position: absolute;
+  inset: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(226, 232, 240, 0.65);
+  border-radius: 0.75rem;
+  font-size: 1.05rem;
+  color: #1f2937;
+}
+
+.scale-info {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.palette-hint {
+  font-size: 0.85rem;
+  margin-top: -0.5rem;
+  margin-bottom: 0.75rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+button,
+.palette-item {
+  font: inherit;
+}
+
+button:focus-visible,
+.palette-item:focus-visible {
+  outline: 2px solid var(--accent-light);
+  outline-offset: 3px;
+}
+
+@media (max-width: 900px) {
+  :root {
+    --sidebar-width: 100%;
+  }
+
+  .app {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem 2rem;
+  }
+
+  .yards-panel {
+    flex: 1 1 220px;
+  }
+
+  .palette {
+    flex: 1 1 220px;
+  }
+
+  .legend {
+    flex: 1 1 160px;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: light;
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  font-size: 68%;
+  font-size: 100%;
 }
 
 .app-shell {
@@ -26,8 +26,8 @@
 body {
   margin: 0;
   background: transparent;
-  font-size: 0.82rem;
-  line-height: 1.45;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
 button,
@@ -85,13 +85,13 @@ textarea {
 
 .brand-copy h1 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1.35rem;
   font-weight: 600;
 }
 
 .brand-copy p {
   margin: 0.15rem 0 0;
-  font-size: 0.68rem;
+  font-size: 0.9rem;
   opacity: 0.7;
 }
 
@@ -151,7 +151,7 @@ textarea {
 
 .section-header h2 {
   margin: 0;
-  font-size: 0.72rem;
+  font-size: 0.95rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   font-weight: 600;
@@ -163,7 +163,7 @@ textarea {
 }
 
 .section-hint {
-  font-size: 0.58rem;
+  font-size: 0.78rem;
   opacity: 0.6;
 }
 
@@ -172,8 +172,8 @@ textarea {
 .btn-ghost,
 .btn-danger {
   border-radius: 0.75rem;
-  padding: 0.45rem 0.7rem;
-  font-size: 0.68rem;
+  padding: 0.55rem 0.85rem;
+  font-size: 0.9rem;
   border: 1px solid transparent;
   background: rgba(148, 163, 184, 0.15);
   color: inherit;
@@ -239,8 +239,8 @@ textarea {
   all: unset;
   width: 100%;
   border-radius: 0.65rem;
-  padding: 0.55rem 0.7rem;
-  font-size: 0.66rem;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.95rem;
   cursor: pointer;
   display: flex;
   justify-content: space-between;
@@ -254,7 +254,7 @@ textarea {
 }
 
 .yard-meta {
-  font-size: 0.58rem;
+  font-size: 0.85rem;
   opacity: 0.65;
 }
 
@@ -283,11 +283,11 @@ textarea {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  padding: 0.45rem 0.65rem;
+  padding: 0.6rem 0.8rem;
   border-radius: 0.65rem;
   background: rgba(148, 163, 184, 0.1);
   cursor: grab;
-  font-size: 0.64rem;
+  font-size: 0.9rem;
   border: 1px solid transparent;
   transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
 }
@@ -345,7 +345,7 @@ textarea {
 }
 
 .yard-summary {
-  font-size: 0.64rem;
+  font-size: 0.95rem;
   display: flex;
   gap: 0.8rem;
   flex-wrap: wrap;
@@ -359,7 +359,7 @@ textarea {
 }
 
 .scale-info {
-  font-size: 0.6rem;
+  font-size: 0.85rem;
   opacity: 0.65;
 }
 
@@ -378,7 +378,7 @@ textarea {
 }
 
 .help-chips li {
-  font-size: 0.58rem;
+  font-size: 0.85rem;
   padding: 0.35rem 0.5rem;
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.16);
@@ -386,7 +386,7 @@ textarea {
 
 .key {
   font-weight: 600;
-  font-size: 0.6rem;
+  font-size: 0.85rem;
   padding: 0.25rem 0.4rem;
   border-radius: 0.35rem;
   background: rgba(59, 130, 246, 0.18);
@@ -441,7 +441,7 @@ textarea {
 }
 
 .container-label {
-  font-size: 0.65rem;
+  font-size: 0.55rem;
   font-weight: 600;
   letter-spacing: 0.06em;
   pointer-events: none;
@@ -452,8 +452,8 @@ textarea {
   top: 1rem;
   left: 50%;
   transform: translateX(-50%);
-  padding: 0.4rem 0.8rem;
-  font-size: 0.7rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
   border-radius: 999px;
   background: rgba(37, 99, 235, 0.18);
   color: inherit;
@@ -488,12 +488,12 @@ textarea {
 
 .empty-card h3 {
   margin: 0 0 0.5rem;
-  font-size: 0.82rem;
+  font-size: 1.05rem;
 }
 
 .empty-card p {
   margin: 0 0 1.2rem;
-  font-size: 0.64rem;
+  font-size: 0.95rem;
   opacity: 0.8;
 }
 
@@ -521,12 +521,12 @@ textarea {
 
 .inventory-header h2 {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: 1.1rem;
 }
 
 .inventory-header p {
   margin: 0.25rem 0 0;
-  font-size: 0.6rem;
+  font-size: 0.9rem;
   opacity: 0.65;
 }
 
@@ -544,7 +544,7 @@ textarea {
 .inventory-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.62rem;
+  font-size: 0.9rem;
 }
 
 .inventory-table th,
@@ -598,7 +598,7 @@ textarea {
   padding: 0.9rem 1rem;
   border-radius: 12px;
   background: rgba(148, 163, 184, 0.12);
-  font-size: 0.64rem;
+  font-size: 0.95rem;
 }
 
 .app-shell[data-theme="dark"] .inventory-overview {
@@ -621,7 +621,7 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.66rem;
+  font-size: 0.95rem;
 }
 
 .form-row input,
@@ -650,7 +650,7 @@ textarea {
 }
 
 .detail-placeholder {
-  font-size: 0.66rem;
+  font-size: 0.95rem;
   opacity: 0.7;
 }
 
@@ -659,7 +659,7 @@ textarea {
   align-items: center;
   gap: 0.45rem;
   cursor: pointer;
-  font-size: 0.6rem;
+  font-size: 0.9rem;
 }
 
 .switch input {
@@ -700,7 +700,7 @@ textarea {
 }
 
 .switch-label {
-  font-size: 0.6rem;
+  font-size: 0.9rem;
   opacity: 0.75;
 }
 
@@ -754,14 +754,14 @@ textarea {
 
 .modal-header h2 {
   margin: 0;
-  font-size: 0.92rem;
+  font-size: 1.2rem;
 }
 
 .modal-body .form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem 1rem;
-  font-size: 0.64rem;
+  font-size: 0.95rem;
 }
 
 .modal-body input,
@@ -786,8 +786,8 @@ textarea {
   background: rgba(148, 163, 184, 0.18);
   border: 2px dashed rgba(148, 163, 184, 0.6);
   color: #1f2937;
-  font-size: 0.75rem;
-  padding: 0.4rem 0.6rem;
+  font-size: 0.95rem;
+  padding: 0.5rem 0.75rem;
   border-radius: 0.6rem;
   backdrop-filter: blur(6px);
 }

--- a/style.css
+++ b/style.css
@@ -68,31 +68,21 @@ textarea {
 
 .brand-block {
   display: flex;
-  gap: 0.75rem;
   align-items: center;
+  max-height: 3.5rem;
 }
 
-.brand-mark {
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 0.9rem;
-  display: grid;
-  place-items: center;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  background: rgba(148, 163, 184, 0.2);
+.brand-logo {
+  height: 3.1rem;
+  width: auto;
+  max-width: 260px;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.35));
 }
 
-.brand-copy h1 {
-  margin: 0;
-  font-size: 1.35rem;
-  font-weight: 600;
-}
-
-.brand-copy p {
-  margin: 0.15rem 0 0;
-  font-size: 0.9rem;
-  opacity: 0.7;
+.app-shell[data-theme="dark"] .brand-logo {
+  filter: drop-shadow(0 6px 18px rgba(2, 6, 23, 0.85));
 }
 
 .header-actions {

--- a/style.css
+++ b/style.css
@@ -105,7 +105,7 @@ textarea {
   flex: 1;
   padding: 1.25rem 2rem 2.5rem;
   display: grid;
-  grid-template-columns: minmax(240px, 260px) minmax(0, 1fr) minmax(240px, 280px);
+  grid-template-columns: minmax(300px, 340px) minmax(0, 1fr) minmax(260px, 300px);
   gap: 1.25rem;
 }
 
@@ -406,6 +406,7 @@ textarea {
     rgba(148, 163, 184, 0.18) 24px
   );
   border: 1px solid rgba(148, 163, 184, 0.25);
+  cursor: grab;
 }
 
 .app-shell[data-theme="dark"] .yard-wrapper {
@@ -414,20 +415,29 @@ textarea {
 }
 
 .yard-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   display: block;
   background: transparent;
+  transform-origin: 0 0;
+  will-change: transform;
 }
 
 .container-group {
   cursor: grab;
-  transition: filter 0.2s ease, transform 0.2s ease;
+  transition: filter 0.2s ease;
 }
 
 .container-group.dragging {
   cursor: grabbing;
   opacity: 0.85;
+}
+
+.yard-wrapper.is-panning {
+  cursor: grabbing;
 }
 
 .container-group.selected .container-rect {
@@ -444,6 +454,13 @@ textarea {
   font-size: 0.55rem;
   font-weight: 600;
   letter-spacing: 0.06em;
+  pointer-events: none;
+}
+
+.container-door {
+  fill: rgba(250, 204, 21, 0.9);
+  stroke: rgba(202, 138, 4, 0.9);
+  stroke-width: 0.08;
   pointer-events: none;
 }
 
@@ -631,6 +648,131 @@ textarea {
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(255, 255, 255, 0.9);
   color: inherit;
+}
+
+.door-fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.9rem;
+  padding: 0.85rem 0.9rem 1rem;
+  gap: 0.75rem;
+}
+
+.app-shell[data-theme="dark"] .door-fieldset {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.door-fieldset legend {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.door-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  opacity: 0.65;
+}
+
+.door-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.door-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.door-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.75rem;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.app-shell[data-theme="dark"] .door-item {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.door-item label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.door-item select,
+.door-item input[type="range"] {
+  width: 100%;
+}
+
+.door-item select {
+  padding: 0.4rem 0.55rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.9);
+  color: inherit;
+}
+
+.app-shell[data-theme="dark"] .door-item select {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.door-item input[type="range"] {
+  accent-color: #2563eb;
+}
+
+.app-shell[data-theme="dark"] .door-item input[type="range"] {
+  accent-color: #60a5fa;
+}
+
+.door-offset {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.door-offset-value {
+  font-size: 0.8rem;
+  font-weight: 600;
+  min-width: 3ch;
+  text-align: right;
+}
+
+.door-remove {
+  border: none;
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+  border-radius: 0.6rem;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+}
+
+.door-remove:hover,
+.door-remove:focus-visible {
+  background: rgba(248, 113, 113, 0.3);
+  outline: none;
+}
+
+.app-shell[data-theme="dark"] .door-remove {
+  background: rgba(248, 113, 113, 0.3);
+  color: #fecaca;
+}
+
+.app-shell[data-theme="dark"] .door-remove:hover,
+.app-shell[data-theme="dark"] .door-remove:focus-visible {
+  background: rgba(248, 113, 113, 0.4);
 }
 
 .input-disabled {

--- a/style.css
+++ b/style.css
@@ -23,6 +23,18 @@ body {
   display: flex;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .app {
   display: flex;
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -1,17 +1,21 @@
 :root {
   color-scheme: light;
-  --bg-surface: #f5f7fb;
-  --bg-panel: rgba(255, 255, 255, 0.92);
-  --bg-header: linear-gradient(120deg, #0f172a, #1e293b 48%, #334155);
-  --outline: #2563eb;
-  --text-primary: #0f172a;
-  --text-subtle: #475569;
-  --accent: #2563eb;
-  --accent-soft: rgba(37, 99, 235, 0.08);
-  --danger: #ef4444;
-  --border: rgba(15, 23, 42, 0.08);
-  --panel-radius: 20px;
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(165deg, #eef1f8 0%, #dde3f3 45%, #cdd8ef 100%);
+  color: #0f172a;
+  transition: background 0.4s ease, color 0.4s ease;
+}
+
+.app-shell[data-theme="dark"] {
+  color-scheme: dark;
+  background: linear-gradient(165deg, #0f172a 0%, #111827 40%, #020817 100%);
+  color: #e2e8f0;
 }
 
 * {
@@ -20,14 +24,13 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
-  background: radial-gradient(circle at top left, #dbeafe, #e2e8f0 40%, #cbd5f5 85%);
-  color: var(--text-primary);
+  background: transparent;
 }
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
 }
 
@@ -43,49 +46,50 @@ select {
   border: 0;
 }
 
-.app-shell {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
 .app-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 1.75rem 2rem;
-  background: var(--bg-header);
+  justify-content: space-between;
+  padding: 1.25rem 2rem;
+  backdrop-filter: blur(18px);
+  background: rgba(15, 23, 42, 0.7);
+  color: #f8fafc;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background 0.4s ease, color 0.4s ease;
+}
+
+.app-shell[data-theme="dark"] .app-header {
+  background: rgba(15, 23, 42, 0.85);
   color: #e2e8f0;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
 }
 
 .brand-block {
   display: flex;
+  gap: 0.75rem;
   align-items: center;
-  gap: 1rem;
 }
 
 .brand-mark {
-  width: 3rem;
-  height: 3rem;
-  border-radius: 1rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.9rem;
   display: grid;
   place-items: center;
-  background: rgba(255, 255, 255, 0.12);
   font-weight: 600;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
+  background: rgba(148, 163, 184, 0.2);
 }
 
 .brand-copy h1 {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 600;
 }
 
 .brand-copy p {
-  margin: 0.2rem 0 0;
-  font-size: 0.95rem;
-  color: rgba(226, 232, 240, 0.85);
+  margin: 0.15rem 0 0;
+  font-size: 0.8rem;
+  opacity: 0.7;
 }
 
 .header-actions {
@@ -96,109 +100,125 @@ select {
 
 .app-body {
   flex: 1;
+  padding: 1.25rem 2rem 2.5rem;
   display: grid;
-  grid-template-columns: minmax(280px, 320px) minmax(0, 1fr) minmax(260px, 320px);
-  gap: 1.5rem;
-  padding: 1.5rem 2rem 2rem;
+  grid-template-columns: minmax(240px, 260px) minmax(0, 1fr) minmax(240px, 280px);
+  gap: 1.25rem;
 }
 
 .panel {
-  backdrop-filter: blur(12px);
-  background: var(--bg-panel);
-  border-radius: var(--panel-radius);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
   display: flex;
   flex-direction: column;
+  backdrop-filter: blur(24px);
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 30px 60px -25px rgba(15, 23, 42, 0.35);
   overflow: hidden;
+  transition: background 0.4s ease, border 0.4s ease, box-shadow 0.4s ease;
+}
+
+.app-shell[data-theme="dark"] .panel {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(148, 163, 184, 0.2);
+  box-shadow: 0 30px 60px -30px rgba(2, 6, 23, 0.8);
 }
 
 .panel-section {
-  padding: 1.5rem;
+  padding: 1.1rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
 .panel-left .panel-section + .panel-section {
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.app-shell[data-theme="dark"] .panel-left .panel-section + .panel-section {
+  border-color: rgba(148, 163, 184, 0.12);
 }
 
 .section-header {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
   gap: 0.75rem;
 }
 
 .section-header h2 {
   margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.section-hint {
   font-size: 0.85rem;
-  color: var(--text-subtle);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
 }
 
 .section-actions {
   display: flex;
-  gap: 0.35rem;
+  gap: 0.4rem;
+}
+
+.section-hint {
+  font-size: 0.7rem;
+  opacity: 0.6;
 }
 
 .btn,
 .btn-primary,
 .btn-ghost,
 .btn-danger {
-  padding: 0.55rem 0.9rem;
-  border-radius: 0.85rem;
+  border-radius: 0.75rem;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.75rem;
   border: 1px solid transparent;
-  background: rgba(148, 163, 184, 0.12);
-  color: var(--text-primary);
+  background: rgba(148, 163, 184, 0.15);
+  color: inherit;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
 }
 
 .btn:hover,
-.btn:focus-visible,
-.btn-primary:hover,
-.btn-primary:focus-visible,
-.btn-ghost:hover,
-.btn-ghost:focus-visible,
-.btn-danger:hover,
-.btn-danger:focus-visible {
+.btn:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.15);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.18);
   outline: none;
 }
 
 .btn-primary {
-  background: var(--accent);
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
   color: #f8fafc;
 }
 
+.app-shell[data-theme="dark"] .btn-primary {
+  background: linear-gradient(135deg, #60a5fa, #3b82f6);
+}
+
 .btn-ghost {
-  background: rgba(148, 163, 184, 0.08);
+  background: rgba(148, 163, 184, 0.12);
 }
 
 .btn-danger {
-  background: rgba(239, 68, 68, 0.12);
+  background: rgba(248, 113, 113, 0.18);
   color: #b91c1c;
+}
+
+.app-shell[data-theme="dark"] .btn-danger {
+  background: rgba(248, 113, 113, 0.24);
+  color: #fecaca;
 }
 
 .btn-icon {
   border: none;
   background: transparent;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   cursor: pointer;
-  color: var(--text-subtle);
+  color: inherit;
 }
 
 .btn-icon:hover,
 .btn-icon:focus-visible {
-  color: var(--accent);
-  outline: none;
+  color: #3b82f6;
 }
 
 .yard-list {
@@ -207,98 +227,110 @@ select {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  max-height: 280px;
-  overflow: auto;
+  gap: 0.35rem;
+  max-height: 320px;
+  overflow-y: auto;
 }
 
-.yard-list button {
+.yard-list li button {
+  all: unset;
   width: 100%;
-  padding: 0.7rem 0.9rem;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(241, 245, 249, 0.7);
-  text-align: left;
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.75rem;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(148, 163, 184, 0.12);
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.yard-list button:hover,
-.yard-list button:focus-visible {
-  border-color: var(--accent);
-  background: rgba(37, 99, 235, 0.12);
+.yard-name {
+  font-weight: 600;
+}
+
+.yard-meta {
+  font-size: 0.68rem;
+  opacity: 0.65;
+}
+
+.yard-list li button:hover,
+.yard-list li button:focus-visible {
+  background: rgba(59, 130, 246, 0.2);
   outline: none;
 }
 
-.yard-list button.active {
-  background: var(--accent-soft);
-  border-color: rgba(37, 99, 235, 0.35);
-  color: var(--accent);
-  transform: translateX(2px);
+.yard-list li button.active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(59, 130, 246, 0.55));
+  color: #0f172a;
+}
+
+.app-shell[data-theme="dark"] .yard-list li button.active {
+  color: #f8fafc;
 }
 
 .palette-items {
-  display: grid;
-  gap: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
 }
 
 .palette-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.8rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(255, 255, 255, 0.5);
+  gap: 0.6rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.65rem;
+  background: rgba(148, 163, 184, 0.1);
   cursor: grab;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.palette-item:hover,
-.palette-item:focus-visible {
-  transform: translateY(-1px) scale(1.01);
-  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
-  outline: none;
+  font-size: 0.75rem;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
 }
 
 .palette-item:active {
   cursor: grabbing;
 }
 
-.palette-item .swatch {
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+.palette-item:hover,
+.palette-item:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.35);
+  outline: none;
 }
 
-.legend-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.legend-list li {
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
-  font-size: 0.9rem;
-}
-
-.legend-list .swatch {
-  width: 1.2rem;
-  height: 1.2rem;
-  border-radius: 0.4rem;
-  border: 1px solid rgba(15, 23, 42, 0.15);
+.palette-mini {
+  height: 0.6rem;
+  border-radius: 0.3rem;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.8), rgba(203, 213, 225, 0.6));
+  flex-shrink: 0;
 }
 
 .workspace {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.workspace-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 24px 48px -28px rgba(15, 23, 42, 0.4);
+  padding: 1rem 1.1rem 1.25rem;
+  transition: background 0.4s ease, border 0.4s ease, box-shadow 0.4s ease;
+}
+
+.app-shell[data-theme="dark"] .workspace-stack {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(148, 163, 184, 0.18);
+  box-shadow: 0 30px 60px -34px rgba(2, 6, 23, 0.9);
 }
 
 .workspace-bar {
@@ -306,83 +338,31 @@ select {
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
-  background: var(--bg-panel);
-  border-radius: var(--panel-radius);
-  padding: 1.2rem 1.5rem;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+  flex-wrap: wrap;
 }
 
 .yard-summary {
-  font-weight: 600;
-  font-size: 1rem;
-  color: var(--text-primary);
+  font-size: 0.78rem;
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  opacity: 0.9;
 }
 
 .workspace-controls {
   display: flex;
   align-items: center;
   gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.switch {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  cursor: pointer;
-}
-
-.switch input {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.switch-slider {
-  width: 3rem;
-  height: 1.5rem;
-  border-radius: 1.5rem;
-  background: rgba(148, 163, 184, 0.6);
-  position: relative;
-  transition: background 0.2s ease;
-}
-
-.switch-slider::after {
-  content: "";
-  position: absolute;
-  top: 0.2rem;
-  left: 0.25rem;
-  width: 1.1rem;
-  height: 1.1rem;
-  background: #fff;
-  border-radius: 50%;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
-  transition: transform 0.2s ease;
-}
-
-.switch input:checked + .switch-slider {
-  background: rgba(37, 99, 235, 0.65);
-}
-
-.switch input:checked + .switch-slider::after {
-  transform: translateX(1.35rem);
-}
-
-.switch-label {
-  font-size: 0.85rem;
-  color: var(--text-subtle);
 }
 
 .scale-info {
-  font-size: 0.85rem;
-  color: var(--text-subtle);
+  font-size: 0.72rem;
+  opacity: 0.65;
 }
 
 .workspace-help {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .help-chips {
@@ -390,46 +370,50 @@ select {
   padding: 0;
   list-style: none;
   display: flex;
-  gap: 0.75rem;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .help-chips li {
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  font-size: 0.7rem;
+  padding: 0.35rem 0.5rem;
   border-radius: 999px;
-  padding: 0.45rem 0.9rem;
-  font-size: 0.85rem;
-  color: var(--text-subtle);
-  display: inline-flex;
-  gap: 0.45rem;
-  align-items: center;
+  background: rgba(148, 163, 184, 0.16);
 }
 
 .key {
-  padding: 0.15rem 0.5rem;
-  border-radius: 0.45rem;
-  background: rgba(15, 23, 42, 0.08);
-  color: var(--text-primary);
   font-weight: 600;
-  font-size: 0.8rem;
+  padding: 0.25rem 0.4rem;
+  border-radius: 0.35rem;
+  background: rgba(59, 130, 246, 0.18);
+  margin-right: 0.35rem;
 }
 
 .yard-wrapper {
   position: relative;
-  flex: 1;
-  min-height: 520px;
-  background: var(--bg-panel);
-  border-radius: var(--panel-radius);
-  border: 1px solid var(--border);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  border-radius: 16px;
   overflow: hidden;
+  min-height: 440px;
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(148, 163, 184, 0.12),
+    rgba(148, 163, 184, 0.12) 12px,
+    rgba(148, 163, 184, 0.18) 12px,
+    rgba(148, 163, 184, 0.18) 24px
+  );
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.app-shell[data-theme="dark"] .yard-wrapper {
+  border-color: rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.55);
 }
 
 .yard-svg {
   width: 100%;
   height: 100%;
   display: block;
-  background: linear-gradient(135deg, rgba(226, 232, 240, 0.8), rgba(248, 250, 252, 0.8));
+  background: transparent;
 }
 
 .container-group {
@@ -439,29 +423,23 @@ select {
 
 .container-group.dragging {
   cursor: grabbing;
-  filter: drop-shadow(0 12px 22px rgba(15, 23, 42, 0.25));
+  opacity: 0.85;
 }
 
 .container-group.selected .container-rect {
-  stroke: var(--accent);
-  stroke-width: 0.18;
+  stroke-width: 0.22;
+  filter: drop-shadow(0 0 0.25rem rgba(59, 130, 246, 0.6));
 }
 
 .container-group.invalid .container-rect {
-  stroke: var(--danger);
-  stroke-width: 0.18;
-}
-
-.container-rect {
-  fill-opacity: 0.9;
-  stroke: rgba(15, 23, 42, 0.18);
-  stroke-width: 0.1;
+  stroke: #f97316;
+  stroke-dasharray: 0.6;
 }
 
 .container-label {
-  fill: #0f172a;
-  font-size: 0.8rem;
+  font-size: 0.65rem;
   font-weight: 600;
+  letter-spacing: 0.06em;
   pointer-events: none;
 }
 
@@ -470,19 +448,18 @@ select {
   top: 1rem;
   left: 50%;
   transform: translateX(-50%);
-  padding: 0.6rem 1rem;
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.7rem;
   border-radius: 999px;
-  font-size: 0.85rem;
+  background: rgba(37, 99, 235, 0.18);
+  color: inherit;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.25s ease, transform 0.25s ease;
+  transition: opacity 0.2s ease;
 }
 
 .hint.visible {
   opacity: 1;
-  transform: translate(-50%, -6px);
 }
 
 .empty-state {
@@ -490,181 +467,360 @@ select {
   inset: 0;
   display: grid;
   place-items: center;
-  background: linear-gradient(145deg, rgba(148, 163, 184, 0.18), rgba(226, 232, 240, 0.3));
-  color: var(--text-primary);
-  text-align: center;
-}
-
-.empty-state[hidden] {
-  display: none;
+  backdrop-filter: blur(6px);
 }
 
 .empty-card {
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: 1.5rem;
-  padding: 2.5rem 3rem;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  max-width: 320px;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 2rem;
+  border-radius: 18px;
+  text-align: center;
+  box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.5);
 }
 
 .empty-card h3 {
-  margin: 0;
-  font-size: 1.4rem;
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
 }
 
-.panel-right {
-  align-self: stretch;
+.empty-card p {
+  margin: 0 0 1.2rem;
+  font-size: 0.78rem;
+  opacity: 0.8;
 }
 
-.detail-placeholder {
-  color: var(--text-subtle);
-  text-align: center;
-  background: rgba(148, 163, 184, 0.1);
-  border-radius: 1rem;
-  padding: 2rem 1.5rem;
-  border: 1px dashed rgba(148, 163, 184, 0.35);
+.app-shell[data-theme="dark"] .empty-card {
+  background: rgba(15, 23, 42, 0.86);
 }
 
-.detail-form {
+.inventory-panel {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding: 1.2rem 1.4rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 24px 48px -30px rgba(15, 23, 42, 0.35);
+  transition: background 0.4s ease, border 0.4s ease, box-shadow 0.4s ease;
+}
+
+.app-shell[data-theme="dark"] .inventory-panel {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(148, 163, 184, 0.18);
+  box-shadow: 0 30px 60px -36px rgba(2, 6, 23, 0.9);
+}
+
+.inventory-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.inventory-header p {
+  margin: 0.25rem 0 0;
+  font-size: 0.7rem;
+  opacity: 0.65;
+}
+
+.inventory-table-wrapper {
+  max-height: 220px;
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.app-shell[data-theme="dark"] .inventory-table-wrapper {
+  border-color: rgba(148, 163, 184, 0.32);
+}
+
+.inventory-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.74rem;
+}
+
+.inventory-table th,
+.inventory-table td {
+  padding: 0.55rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.app-shell[data-theme="dark"] .inventory-table th,
+.app-shell[data-theme="dark"] .inventory-table td {
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.inventory-table thead {
+  background: rgba(148, 163, 184, 0.16);
+  position: sticky;
+  top: 0;
+}
+
+.app-shell[data-theme="dark"] .inventory-table thead {
+  background: rgba(148, 163, 184, 0.22);
+}
+
+.inventory-table tbody tr:hover {
+  background: rgba(59, 130, 246, 0.16);
+}
+
+.app-shell[data-theme="dark"] .inventory-table tbody tr:hover {
+  background: rgba(59, 130, 246, 0.25);
+}
+
+.inventory-table td.numeric,
+.inventory-table th.numeric {
+  text-align: right;
+}
+
+.inventory-table tbody tr.vacant-row td:first-child {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.inventory-table tbody tr.occupied-row td:first-child {
+  color: #22c55e;
+  font-weight: 600;
+}
+
+.inventory-overview {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.12);
+  font-size: 0.75rem;
+}
+
+.app-shell[data-theme="dark"] .inventory-overview {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.overview-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.panel-right .detail-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
 .form-row {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-}
-
-.form-row label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--text-subtle);
+  gap: 0.35rem;
+  font-size: 0.75rem;
 }
 
 .form-row input,
-.form-grid input,
-.form-grid select {
-  padding: 0.65rem 0.8rem;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+.form-row select {
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(255, 255, 255, 0.9);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  color: inherit;
+}
+
+.input-disabled {
+  opacity: 0.55;
+}
+
+.app-shell[data-theme="dark"] .form-row input,
+.app-shell[data-theme="dark"] .form-row select {
+  background: rgba(15, 23, 42, 0.8);
+  border-color: rgba(148, 163, 184, 0.35);
 }
 
 .form-row input:focus-visible,
-.form-grid input:focus-visible,
-.form-grid select:focus-visible {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
-  outline: none;
+.form-row select:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.5);
+  outline-offset: 1px;
 }
 
-.modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.55);
-  display: grid;
-  place-items: center;
-  z-index: 40;
+.detail-placeholder {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  cursor: pointer;
+  font-size: 0.72rem;
+}
+
+.switch input {
+  appearance: none;
+  width: 38px;
+  height: 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.2);
+  position: relative;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.app-shell[data-theme="dark"] .switch input {
+  border-color: rgba(148, 163, 184, 0.5);
+  background: rgba(51, 65, 85, 0.6);
+}
+
+.switch input::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked {
+  background: rgba(59, 130, 246, 0.8);
+  border-color: rgba(59, 130, 246, 0.9);
+}
+
+.switch input:checked::after {
+  transform: translateX(18px);
+}
+
+.switch-label {
+  font-size: 0.72rem;
+  opacity: 0.75;
+}
+
+.switch-theme {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.28);
+}
+
+.app-shell[data-theme="dark"] .switch-theme {
+  background: rgba(148, 163, 184, 0.25);
 }
 
 .modal-backdrop[hidden] {
   display: none;
 }
 
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 1000;
+}
+
 .modal {
-  width: min(420px, calc(100% - 2rem));
+  width: min(440px, 92vw);
 }
 
 .modal-content {
-  background: var(--bg-panel);
-  border-radius: 1.5rem;
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.3);
   display: flex;
   flex-direction: column;
+  gap: 1.2rem;
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: 18px;
+  padding: 1.4rem 1.6rem 1.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-.modal-header,
-.modal-footer {
-  padding: 1.25rem 1.5rem;
+.app-shell[data-theme="dark"] .modal-content {
+  background: rgba(15, 23, 42, 0.88);
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.modal-header {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
 }
 
 .modal-header h2 {
   margin: 0;
-  font-size: 1.2rem;
+  font-size: 1.05rem;
 }
 
-.modal-body {
-  padding: 0 1.5rem 1.5rem;
-}
-
-.form-grid {
+.modal-body .form-grid {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1rem;
+  font-size: 0.78rem;
 }
 
-.form-grid label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--text-subtle);
+.modal-body input,
+.modal-body select {
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.9);
+  color: inherit;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
 }
 
 .drag-ghost {
   position: fixed;
   pointer-events: none;
-  padding: 0.5rem 0.8rem;
-  border-radius: 0.8rem;
-  border: 2px solid var(--accent);
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
-  font-size: 0.85rem;
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.3);
-  z-index: 100;
+  z-index: 999;
+  background: rgba(148, 163, 184, 0.18);
+  border: 2px dashed rgba(148, 163, 184, 0.6);
+  color: #1f2937;
+  font-size: 0.75rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.6rem;
+  backdrop-filter: blur(6px);
 }
 
-@media (max-width: 1100px) {
+.app-shell[data-theme="dark"] .drag-ghost {
+  background: rgba(30, 41, 59, 0.7);
+  border-color: rgba(148, 163, 184, 0.5);
+  color: #e2e8f0;
+}
+
+@media (max-width: 1200px) {
   .app-body {
-    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+    grid-template-columns: minmax(220px, 240px) minmax(0, 1fr);
     grid-template-areas:
       "left main"
-      "right right";
+      "left right";
+    grid-auto-rows: min-content;
   }
 
   .panel-right {
     grid-area: right;
-    margin-top: 1.5rem;
-  }
-}
-
-@media (max-width: 840px) {
-  .app-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
-  }
-
-  .app-body {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .panel-left {
-    order: 2;
   }
 
   .workspace {
-    order: 1;
+    grid-area: main;
   }
 
-  .panel-right {
-    order: 3;
+  .panel-left {
+    grid-area: left;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-body {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: none;
+  }
+
+  .panel-left,
+  .panel-right,
+  .workspace {
+    grid-area: unset;
   }
 }

--- a/style.css
+++ b/style.css
@@ -239,8 +239,8 @@ textarea {
   all: unset;
   width: 100%;
   border-radius: 0.65rem;
-  padding: 0.65rem 0.85rem;
-  font-size: 0.95rem;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.9rem;
   cursor: pointer;
   display: flex;
   justify-content: space-between;

--- a/style.css
+++ b/style.css
@@ -1,14 +1,17 @@
 :root {
-  color-scheme: light dark;
-  --sidebar-width: min(320px, 30vw);
-  --bg: #f2f4f8;
-  --sidebar-bg: #1f2933;
-  --sidebar-text: #f5f7fa;
-  --accent: #3b82f6;
-  --accent-light: #93c5fd;
-  --border: #cbd5e1;
+  color-scheme: light;
+  --bg-surface: #f5f7fb;
+  --bg-panel: rgba(255, 255, 255, 0.92);
+  --bg-header: linear-gradient(120deg, #0f172a, #1e293b 48%, #334155);
+  --outline: #2563eb;
+  --text-primary: #0f172a;
+  --text-subtle: #475569;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.08);
   --danger: #ef4444;
-  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --border: rgba(15, 23, 42, 0.08);
+  --panel-radius: 20px;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 * {
@@ -18,9 +21,14 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--bg);
-  color: #1f2933;
-  display: flex;
+  background: radial-gradient(circle at top left, #dbeafe, #e2e8f0 40%, #cbd5f5 85%);
+  color: var(--text-primary);
+}
+
+button,
+input,
+select {
+  font: inherit;
 }
 
 .sr-only {
@@ -35,92 +43,222 @@ body {
   border: 0;
 }
 
-.app {
-  display: flex;
-  width: 100%;
-}
-
-.sidebar {
-  width: var(--sidebar-width);
-  background: var(--sidebar-bg);
-  color: var(--sidebar-text);
-  padding: 1.25rem;
+.app-shell {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  min-height: 100vh;
 }
 
-.sidebar h1,
-.sidebar h2 {
-  margin: 0 0 0.75rem 0;
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.75rem 2rem;
+  background: var(--bg-header);
+  color: #e2e8f0;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+}
+
+.brand-block {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-mark {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.12);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.brand-copy h1 {
+  margin: 0;
+  font-size: 1.5rem;
   font-weight: 600;
 }
 
-.yard-actions {
+.brand-copy p {
+  margin: 0.2rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-body {
+  flex: 1;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.5rem;
+  grid-template-columns: minmax(280px, 320px) minmax(0, 1fr) minmax(260px, 320px);
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
 }
 
-.yard-actions button {
-  padding: 0.5rem 0.75rem;
-  border: none;
-  border-radius: 0.5rem;
-  background: #334155;
-  color: var(--sidebar-text);
+.panel {
+  backdrop-filter: blur(12px);
+  background: var(--bg-panel);
+  border-radius: var(--panel-radius);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.panel-section {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-left .panel-section + .panel-section {
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.section-hint {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.section-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.btn,
+.btn-primary,
+.btn-ghost,
+.btn-danger {
+  padding: 0.55rem 0.9rem;
+  border-radius: 0.85rem;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-primary);
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
-.yard-actions button:hover,
-.yard-actions button:focus-visible {
-  background: #475569;
+.btn:hover,
+.btn:focus-visible,
+.btn-primary:hover,
+.btn-primary:focus-visible,
+.btn-ghost:hover,
+.btn-ghost:focus-visible,
+.btn-danger:hover,
+.btn-danger:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.15);
+  outline: none;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #f8fafc;
+}
+
+.btn-ghost {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.btn-danger {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+}
+
+.btn-icon {
+  border: none;
+  background: transparent;
+  font-size: 1.6rem;
+  cursor: pointer;
+  color: var(--text-subtle);
+}
+
+.btn-icon:hover,
+.btn-icon:focus-visible {
+  color: var(--accent);
   outline: none;
 }
 
 .yard-list {
   list-style: none;
-  padding: 0;
   margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  max-height: 25vh;
+  gap: 0.6rem;
+  max-height: 280px;
   overflow: auto;
 }
 
 .yard-list button {
   width: 100%;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
-  background: transparent;
-  color: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.7rem 0.9rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(241, 245, 249, 0.7);
   text-align: left;
   cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.yard-list button:hover,
+.yard-list button:focus-visible {
+  border-color: var(--accent);
+  background: rgba(37, 99, 235, 0.12);
+  outline: none;
 }
 
 .yard-list button.active {
-  background: rgba(59, 130, 246, 0.3);
-  border-color: var(--accent-light);
+  background: var(--accent-soft);
+  border-color: rgba(37, 99, 235, 0.35);
+  color: var(--accent);
+  transform: translateX(2px);
 }
 
 .palette-items {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  gap: 0.75rem;
 }
 
 .palette-item {
-  background: rgba(148, 163, 184, 0.2);
-  border-radius: 0.5rem;
-  padding: 0.75rem;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.5);
   cursor: grab;
-  color: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.palette-item:hover,
+.palette-item:focus-visible {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+  outline: none;
 }
 
 .palette-item:active {
@@ -128,123 +266,203 @@ body {
 }
 
 .palette-item .swatch {
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: 0.35rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
 }
 
-.legend ul,
-.legend li {
+.legend-list {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.legend li {
+.legend-list li {
   display: flex;
+  gap: 0.6rem;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.legend-list .swatch {
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(15, 23, 42, 0.15);
 }
 
 .workspace {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 1.25rem;
   gap: 1rem;
 }
 
-.workspace-header {
+.workspace-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap;
   gap: 1rem;
+  background: var(--bg-panel);
+  border-radius: var(--panel-radius);
+  padding: 1.2rem 1.5rem;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+}
+
+.yard-summary {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-primary);
 }
 
 .workspace-controls {
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
-.snap-toggle {
+.switch {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   cursor: pointer;
-  color: inherit;
 }
 
-.snap-toggle input {
-  width: 1.15rem;
-  height: 1.15rem;
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch-slider {
+  width: 3rem;
+  height: 1.5rem;
+  border-radius: 1.5rem;
+  background: rgba(148, 163, 184, 0.6);
+  position: relative;
+  transition: background 0.2s ease;
+}
+
+.switch-slider::after {
+  content: "";
+  position: absolute;
+  top: 0.2rem;
+  left: 0.25rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked + .switch-slider {
+  background: rgba(37, 99, 235, 0.65);
+}
+
+.switch input:checked + .switch-slider::after {
+  transform: translateX(1.35rem);
+}
+
+.switch-label {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.scale-info {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.workspace-help {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.help-chips {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.help-chips li {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.key {
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.45rem;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 0.8rem;
 }
 
 .yard-wrapper {
   position: relative;
   flex: 1;
-  background: white;
-  border-radius: 1rem;
+  min-height: 520px;
+  background: var(--bg-panel);
+  border-radius: var(--panel-radius);
   border: 1px solid var(--border);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
-  padding: 1rem;
-  overflow: auto;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  overflow: hidden;
 }
 
 .yard-svg {
   width: 100%;
   height: 100%;
-  min-height: 400px;
   display: block;
-  background: #f8fafc;
-  border-radius: 0.75rem;
-  border: 1px solid #e2e8f0;
+  background: linear-gradient(135deg, rgba(226, 232, 240, 0.8), rgba(248, 250, 252, 0.8));
 }
 
 .container-group {
   cursor: grab;
-}
-
-.container-group:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.container-rect {
-  fill: var(--accent-light);
-  stroke: #1e3a8a;
-  stroke-width: 0.05;
-  rx: 0.2;
-  ry: 0.2;
-}
-
-.container-group[data-type="5ft"] .container-rect { fill: #8ecae6; stroke: #126782; }
-.container-group[data-type="10ft"] .container-rect { fill: #a3bffa; stroke: #1e3a8a; }
-.container-group[data-type="20ft"] .container-rect { fill: #facc15; stroke: #a16207; }
-.container-group[data-type="40ft"] .container-rect { fill: #f87171; stroke: #b91c1c; }
-.container-group[data-type="50ft"] .container-rect { fill: #c084fc; stroke: #6b21a8; }
-
-.container-label {
-  fill: #1f2933;
-  font-size: 0.7rem;
-  pointer-events: none;
-}
-
-.container-group.selected .container-rect {
-  stroke: #0f172a;
-  stroke-width: 0.12;
-  filter: brightness(0.95);
+  transition: filter 0.2s ease, transform 0.2s ease;
 }
 
 .container-group.dragging {
-  opacity: 0.7;
+  cursor: grabbing;
+  filter: drop-shadow(0 12px 22px rgba(15, 23, 42, 0.25));
+}
+
+.container-group.selected .container-rect {
+  stroke: var(--accent);
+  stroke-width: 0.18;
 }
 
 .container-group.invalid .container-rect {
   stroke: var(--danger);
-  stroke-dasharray: 0.4;
+  stroke-width: 0.18;
+}
+
+.container-rect {
+  fill-opacity: 0.9;
+  stroke: rgba(15, 23, 42, 0.18);
+  stroke-width: 0.1;
+}
+
+.container-label {
+  fill: #0f172a;
+  font-size: 0.8rem;
+  font-weight: 600;
+  pointer-events: none;
 }
 
 .hint {
@@ -252,93 +470,201 @@ body {
   top: 1rem;
   left: 50%;
   transform: translateX(-50%);
-  padding: 0.5rem 0.75rem;
+  padding: 0.6rem 1rem;
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
   border-radius: 999px;
-  background: rgba(30, 64, 175, 0.85);
-  color: white;
   font-size: 0.85rem;
-  pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s ease;
-  z-index: 10;
+  pointer-events: none;
+  transition: opacity 0.25s ease, transform 0.25s ease;
 }
 
 .hint.visible {
   opacity: 1;
+  transform: translate(-50%, -6px);
+}
+
+.empty-state {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, rgba(148, 163, 184, 0.18), rgba(226, 232, 240, 0.3));
+  color: var(--text-primary);
+  text-align: center;
+}
+
+.empty-state[hidden] {
+  display: none;
+}
+
+.empty-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 1.5rem;
+  padding: 2.5rem 3rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 320px;
+}
+
+.empty-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.panel-right {
+  align-self: stretch;
+}
+
+.detail-placeholder {
+  color: var(--text-subtle);
+  text-align: center;
+  background: rgba(148, 163, 184, 0.1);
+  border-radius: 1rem;
+  padding: 2rem 1.5rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+}
+
+.detail-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-row label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-subtle);
+}
+
+.form-row input,
+.form-grid input,
+.form-grid select {
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-row input:focus-visible,
+.form-grid input:focus-visible,
+.form-grid select:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  place-items: center;
+  z-index: 40;
+}
+
+.modal-backdrop[hidden] {
+  display: none;
+}
+
+.modal {
+  width: min(420px, calc(100% - 2rem));
+}
+
+.modal-content {
+  background: var(--bg-panel);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.3);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header,
+.modal-footer {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.modal-body {
+  padding: 0 1.5rem 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+.form-grid label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-subtle);
 }
 
 .drag-ghost {
   position: fixed;
   pointer-events: none;
-  background: rgba(255, 255, 255, 0.9);
-  color: #0f172a;
-  border: 2px dashed;
-  border-radius: 0.5rem;
-  padding: 0.4rem 0.6rem;
-  font-weight: 600;
-  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.15);
-  z-index: 20;
-}
-
-.empty-state {
-  position: absolute;
-  inset: 2rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: rgba(226, 232, 240, 0.65);
-  border-radius: 0.75rem;
-  font-size: 1.05rem;
-  color: #1f2937;
-}
-
-.scale-info {
-  font-weight: 600;
-  color: #0f172a;
-}
-
-.palette-hint {
+  padding: 0.5rem 0.8rem;
+  border-radius: 0.8rem;
+  border: 2px solid var(--accent);
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
   font-size: 0.85rem;
-  margin-top: -0.5rem;
-  margin-bottom: 0.75rem;
-  color: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.3);
+  z-index: 100;
 }
 
-button,
-.palette-item {
-  font: inherit;
-}
-
-button:focus-visible,
-.palette-item:focus-visible {
-  outline: 2px solid var(--accent-light);
-  outline-offset: 3px;
-}
-
-@media (max-width: 900px) {
-  :root {
-    --sidebar-width: 100%;
+@media (max-width: 1100px) {
+  .app-body {
+    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+    grid-template-areas:
+      "left main"
+      "right right";
   }
 
-  .app {
+  .panel-right {
+    grid-area: right;
+    margin-top: 1.5rem;
+  }
+}
+
+@media (max-width: 840px) {
+  .app-header {
     flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
   }
 
-  .sidebar {
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 1rem 2rem;
+  .app-body {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .yards-panel {
-    flex: 1 1 220px;
+  .panel-left {
+    order: 2;
   }
 
-  .palette {
-    flex: 1 1 220px;
+  .workspace {
+    order: 1;
   }
 
-  .legend {
-    flex: 1 1 160px;
+  .panel-right {
+    order: 3;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1,6 +1,7 @@
 :root {
   color-scheme: light;
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 68%;
 }
 
 .app-shell {
@@ -25,6 +26,8 @@
 body {
   margin: 0;
   background: transparent;
+  font-size: 0.82rem;
+  line-height: 1.45;
 }
 
 button,
@@ -82,13 +85,13 @@ textarea {
 
 .brand-copy h1 {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1.05rem;
   font-weight: 600;
 }
 
 .brand-copy p {
   margin: 0.15rem 0 0;
-  font-size: 0.8rem;
+  font-size: 0.68rem;
   opacity: 0.7;
 }
 
@@ -148,7 +151,7 @@ textarea {
 
 .section-header h2 {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.72rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   font-weight: 600;
@@ -160,7 +163,7 @@ textarea {
 }
 
 .section-hint {
-  font-size: 0.7rem;
+  font-size: 0.58rem;
   opacity: 0.6;
 }
 
@@ -170,7 +173,7 @@ textarea {
 .btn-danger {
   border-radius: 0.75rem;
   padding: 0.45rem 0.7rem;
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   border: 1px solid transparent;
   background: rgba(148, 163, 184, 0.15);
   color: inherit;
@@ -237,7 +240,7 @@ textarea {
   width: 100%;
   border-radius: 0.65rem;
   padding: 0.55rem 0.7rem;
-  font-size: 0.75rem;
+  font-size: 0.66rem;
   cursor: pointer;
   display: flex;
   justify-content: space-between;
@@ -251,7 +254,7 @@ textarea {
 }
 
 .yard-meta {
-  font-size: 0.68rem;
+  font-size: 0.58rem;
   opacity: 0.65;
 }
 
@@ -284,7 +287,7 @@ textarea {
   border-radius: 0.65rem;
   background: rgba(148, 163, 184, 0.1);
   cursor: grab;
-  font-size: 0.75rem;
+  font-size: 0.64rem;
   border: 1px solid transparent;
   transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
 }
@@ -342,7 +345,7 @@ textarea {
 }
 
 .yard-summary {
-  font-size: 0.78rem;
+  font-size: 0.64rem;
   display: flex;
   gap: 0.8rem;
   flex-wrap: wrap;
@@ -356,7 +359,7 @@ textarea {
 }
 
 .scale-info {
-  font-size: 0.72rem;
+  font-size: 0.6rem;
   opacity: 0.65;
 }
 
@@ -375,7 +378,7 @@ textarea {
 }
 
 .help-chips li {
-  font-size: 0.7rem;
+  font-size: 0.58rem;
   padding: 0.35rem 0.5rem;
   border-radius: 999px;
   background: rgba(148, 163, 184, 0.16);
@@ -383,6 +386,7 @@ textarea {
 
 .key {
   font-weight: 600;
+  font-size: 0.6rem;
   padding: 0.25rem 0.4rem;
   border-radius: 0.35rem;
   background: rgba(59, 130, 246, 0.18);
@@ -470,6 +474,10 @@ textarea {
   backdrop-filter: blur(6px);
 }
 
+.empty-state[hidden] {
+  display: none;
+}
+
 .empty-card {
   background: rgba(255, 255, 255, 0.92);
   padding: 2rem;
@@ -480,12 +488,12 @@ textarea {
 
 .empty-card h3 {
   margin: 0 0 0.5rem;
-  font-size: 1rem;
+  font-size: 0.82rem;
 }
 
 .empty-card p {
   margin: 0 0 1.2rem;
-  font-size: 0.78rem;
+  font-size: 0.64rem;
   opacity: 0.8;
 }
 
@@ -513,12 +521,12 @@ textarea {
 
 .inventory-header h2 {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.82rem;
 }
 
 .inventory-header p {
   margin: 0.25rem 0 0;
-  font-size: 0.7rem;
+  font-size: 0.6rem;
   opacity: 0.65;
 }
 
@@ -536,12 +544,12 @@ textarea {
 .inventory-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.74rem;
+  font-size: 0.62rem;
 }
 
 .inventory-table th,
 .inventory-table td {
-  padding: 0.55rem 0.75rem;
+  padding: 0.4rem 0.6rem;
   text-align: left;
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
@@ -590,7 +598,7 @@ textarea {
   padding: 0.9rem 1rem;
   border-radius: 12px;
   background: rgba(148, 163, 184, 0.12);
-  font-size: 0.75rem;
+  font-size: 0.64rem;
 }
 
 .app-shell[data-theme="dark"] .inventory-overview {
@@ -613,7 +621,7 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.75rem;
+  font-size: 0.66rem;
 }
 
 .form-row input,
@@ -642,7 +650,7 @@ textarea {
 }
 
 .detail-placeholder {
-  font-size: 0.75rem;
+  font-size: 0.66rem;
   opacity: 0.7;
 }
 
@@ -651,7 +659,7 @@ textarea {
   align-items: center;
   gap: 0.45rem;
   cursor: pointer;
-  font-size: 0.72rem;
+  font-size: 0.6rem;
 }
 
 .switch input {
@@ -692,7 +700,7 @@ textarea {
 }
 
 .switch-label {
-  font-size: 0.72rem;
+  font-size: 0.6rem;
   opacity: 0.75;
 }
 
@@ -746,14 +754,14 @@ textarea {
 
 .modal-header h2 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 0.92rem;
 }
 
 .modal-body .form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem 1rem;
-  font-size: 0.78rem;
+  font-size: 0.64rem;
 }
 
 .modal-body input,


### PR DESCRIPTION
## Summary
- add an index shell with sidebar management UI and responsive workspace for yards
- implement SVG-based yard rendering with drag/drop containers, grid snapping, collision checks, and keyboard interactions
- persist yards and placements in localStorage with autosave and provide accessible hints, palette, and legend styling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68e03d579254832397bbfb787ea87a19